### PR TITLE
Introduce Fast PID in reconstruction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,59 @@
-# Prerequisites
-*.d
+# http://www.gnu.org/software/automake
+
+Makefile.in
+
+# http://www.gnu.org/software/autoconf
+
+autom4te.cache
+aclocal.m4
+compile
+configure
+depcomp
+install-sh
+missing
+stamp-h1
+
+config.guess
+config.sub
+ltmain.sh
+
+build
+
+# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
+#
+# * Create a file at ~/.gitignore
+# * Include files you want ignored
+# * Run: git config --global core.excludesfile ~/.gitignore
+#
+# After doing this, these files will be ignored in all your git projects,
+# saving you from having to 'pollute' every project you touch with them
+#
+# For MacOS:
+#
+.DS_Store
+
+# ignore RVM configuration
+.rvmrc
+
+# For TextMate
+*.tmproj
+tmtags
+
+# For emacs:
+*~
+\#*
+.\#*
+
+# For vim:
+*.swp
+
+# For redcar:
+.redcar
+
+# For rubinius:
+*.rbc
+
+# standard C++ Git igore
 
 # Compiled Object files
 *.slo
@@ -18,15 +72,19 @@
 
 # Fortran module files
 *.mod
-*.smod
 
 # Compiled Static libraries
 *.lai
 *.la
 *.a
 *.lib
+*.pcm
+*_Dict.cc
+*.status
 
 # Executables
 *.exe
 *.out
 *.app
+/.cproject
+/.project

--- a/FastPID/ECCEFastPIDMap.cc
+++ b/FastPID/ECCEFastPIDMap.cc
@@ -9,9 +9,16 @@
 //____________________________________________________________________________..
 ECCEFastPIDMap::ECCEFastPIDMap(const std::string &name)
 {
+
 }
 
 //____________________________________________________________________________..
 ECCEFastPIDMap::~ECCEFastPIDMap()
 {
+
+}
+
+EICPIDDefs::PIDCandidate getFastSmearPID(int truth_pid, const double momentum)
+{
+  return EICPIDDefs::InvalidCandiate;
 }

--- a/FastPID/ECCEFastPIDMap.cc
+++ b/FastPID/ECCEFastPIDMap.cc
@@ -7,18 +7,11 @@
 #include <phool/PHCompositeNode.h>
 
 //____________________________________________________________________________..
-ECCEFastPIDMap::ECCEFastPIDMap(const std::string &name)
-{
-
-}
+ECCEFastPIDMap::ECCEFastPIDMap(const std::string &name) {}
 
 //____________________________________________________________________________..
-ECCEFastPIDMap::~ECCEFastPIDMap()
-{
+ECCEFastPIDMap::~ECCEFastPIDMap() {}
 
-}
-
-EICPIDDefs::PIDCandidate getFastSmearPID(int truth_pid, const double momentum)
-{
+EICPIDDefs::PIDCandidate getFastSmearPID(int truth_pid, const double momentum) {
   return EICPIDDefs::InvalidCandiate;
 }

--- a/FastPID/ECCEFastPIDMap.cc
+++ b/FastPID/ECCEFastPIDMap.cc
@@ -1,0 +1,17 @@
+
+
+#include "ECCEFastPIDMap.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+
+//____________________________________________________________________________..
+ECCEFastPIDMap::ECCEFastPIDMap(const std::string &name)
+{
+}
+
+//____________________________________________________________________________..
+ECCEFastPIDMap::~ECCEFastPIDMap()
+{
+}

--- a/FastPID/ECCEFastPIDMap.h
+++ b/FastPID/ECCEFastPIDMap.h
@@ -22,11 +22,19 @@ class ECCEFastPIDMap
   typedef std::map<EICPIDDefs::PIDCandidate, float> PIDCandidate_LogLikelihood_map;
 
   virtual PIDCandidate_LogLikelihood_map
-    getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta) const = 0;
+  getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta) const = 0;
 
-//  EICPIDDefs::PIDCandidate getFastSmearPID(int truth_pid, const double momentum);
+  //  EICPIDDefs::PIDCandidate getFastSmearPID(int truth_pid, const double momentum);
+
+  /// Sets the verbosity of this module (0 by default=quiet).
+  virtual void Verbosity(const int ival) { m_Verbosity = ival; }
+
+  /// Gets the verbosity of this module.
+  virtual int Verbosity() const { return m_Verbosity; }
 
  private:
+  /// The verbosity level. 0 means not verbose at all.
+  int m_Verbosity = 0;
 };
 
 #endif  // ECCEFastPIDMap_H

--- a/FastPID/ECCEFastPIDMap.h
+++ b/FastPID/ECCEFastPIDMap.h
@@ -12,19 +12,21 @@
 
 class PHCompositeNode;
 
-class ECCEFastPIDMap
-{
- public:
+class ECCEFastPIDMap {
+public:
   ECCEFastPIDMap(const std::string &name = "ECCEFastPIDMap");
 
   virtual ~ECCEFastPIDMap();
 
-  typedef std::map<EICPIDDefs::PIDCandidate, float> PIDCandidate_LogLikelihood_map;
+  typedef std::map<EICPIDDefs::PIDCandidate, float>
+      PIDCandidate_LogLikelihood_map;
 
   virtual PIDCandidate_LogLikelihood_map
-  getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta) const = 0;
+  getFastSmearLogLikelihood(int truth_pid, const double momentum,
+                            const double theta) const = 0;
 
-  //  EICPIDDefs::PIDCandidate getFastSmearPID(int truth_pid, const double momentum);
+  //  EICPIDDefs::PIDCandidate getFastSmearPID(int truth_pid, const double
+  //  momentum);
 
   /// Sets the verbosity of this module (0 by default=quiet).
   virtual void Verbosity(const int ival) { m_Verbosity = ival; }
@@ -32,9 +34,9 @@ class ECCEFastPIDMap
   /// Gets the verbosity of this module.
   virtual int Verbosity() const { return m_Verbosity; }
 
- private:
+private:
   /// The verbosity level. 0 means not verbose at all.
   int m_Verbosity = 0;
 };
 
-#endif  // ECCEFastPIDMap_H
+#endif // ECCEFastPIDMap_H

--- a/FastPID/ECCEFastPIDMap.h
+++ b/FastPID/ECCEFastPIDMap.h
@@ -1,0 +1,26 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef ECCEFastPIDMap_H
+#define ECCEFastPIDMap_H
+
+#include <eicpidbase/EICPIDDefs.h>
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+
+class PHCompositeNode;
+
+class ECCEFastPIDMap
+{
+ public:
+
+  ECCEFastPIDMap(const std::string &name = "ECCEFastPIDMap");
+
+  virtual ~ECCEFastPIDMap();
+
+
+ private:
+};
+
+#endif // ECCEFastPIDMap_H

--- a/FastPID/ECCEFastPIDMap.h
+++ b/FastPID/ECCEFastPIDMap.h
@@ -7,6 +7,7 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <map>
 #include <string>
 
 class PHCompositeNode;
@@ -14,13 +15,18 @@ class PHCompositeNode;
 class ECCEFastPIDMap
 {
  public:
-
   ECCEFastPIDMap(const std::string &name = "ECCEFastPIDMap");
 
   virtual ~ECCEFastPIDMap();
 
+  typedef std::map<EICPIDDefs::PIDCandidate, float> PIDCandidate_LogLikelihood_map;
+
+  virtual PIDCandidate_LogLikelihood_map
+    getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta) const = 0;
+
+//  EICPIDDefs::PIDCandidate getFastSmearPID(int truth_pid, const double momentum);
 
  private:
 };
 
-#endif // ECCEFastPIDMap_H
+#endif  // ECCEFastPIDMap_H

--- a/FastPID/ECCEFastPIDReco.cc
+++ b/FastPID/ECCEFastPIDReco.cc
@@ -1,0 +1,123 @@
+
+#include "ECCEFastPIDReco.h"
+#include "ECCEFastPIDMap.h"
+
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxTrack_FastSim.h>
+
+#include <eicpidbase/EICPIDParticle.h>
+#include <eicpidbase/EICPIDParticleContainer.h>
+
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNode.h>  // for PHNode
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>  // for PHObject
+#include <phool/PHRandomSeed.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <cassert>
+#include <iostream>
+
+using namespace std;
+
+//____________________________________________________________________________..
+ECCEFastPIDReco::ECCEFastPIDReco(const std::string &name)
+  : SubsysReco(name)
+{
+  std::cout << "ECCEFastPIDReco::ECCEFastPIDReco(const std::string &name) Calling ctor" << std::endl;
+}
+
+//____________________________________________________________________________..
+ECCEFastPIDReco::~ECCEFastPIDReco()
+{
+  if (m_pidmap) delete m_pidmap;
+}
+
+//____________________________________________________________________________..
+int ECCEFastPIDReco::Init(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int ECCEFastPIDReco::InitRun(PHCompositeNode *topNode)
+{
+  m_SvtxTrackMap = findNode::getClass<SvtxTrackMap>(topNode, m_TrackmapNodeName);
+  if (!m_SvtxTrackMap)
+  {
+    cout << __PRETTY_FUNCTION__ << " fatal error missing node " << m_TrackmapNodeName << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_EICPIDParticleContainer = findNode::getClass<EICPIDParticleContainer>(topNode, m_EICPIDParticleMapNodeName);
+  if (!m_EICPIDParticleContainer)
+  {
+    m_EICPIDParticleContainer = new EICPIDParticleContainer;
+
+    PHIODataNode<PHObject> *pid_node = new PHIODataNode<PHObject>(m_EICPIDParticleContainer, m_EICPIDParticleMapNodeName, "PHObject");
+    topNode->addNode(pid_node);
+    if (Verbosity() > 0)
+    {
+      cout << m_EICPIDParticleMapNodeName << " node added" << endl;
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int ECCEFastPIDReco::process_event(PHCompositeNode *topNode)
+{
+  assert(m_SvtxTrackMap);
+  assert(m_EICPIDParticleContainer);
+
+  for (const auto &track_pair : *m_SvtxTrackMap)
+  {
+    const SvtxTrack *track = track_pair.second;
+    assert(track);
+
+    const SvtxTrack_FastSim *fasttrack = dynamic_cast<const SvtxTrack_FastSim *>(track);
+
+    if (!fasttrack)
+    {
+      if (Verbosity())
+      {
+        cout << __PRETTY_FUNCTION__ << " : ignore none SvtxTrack_FastSim track: ";
+        track->identify();
+      }
+    }
+    else
+    {  // process track
+      auto iter = m_EICPIDParticleContainer->findOrAddPIDParticle(track->get_id());
+
+      EICPIDParticle *pidparticle = iter->second;
+
+      assert(pidparticle);
+    }
+  }
+
+  if (Verbosity())
+  {
+    cout << __PRETTY_FUNCTION__ << " : done processing from trackmap ";
+    m_SvtxTrackMap->identify();
+    cout << __PRETTY_FUNCTION__ << " : produced EICPIDParticleContainer ";
+    m_EICPIDParticleContainer->identify();
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int ECCEFastPIDReco::End(PHCompositeNode *topNode)
+{
+  std::cout << "ECCEFastPIDReco::End(PHCompositeNode *topNode) This is the End..." << std::endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/FastPID/ECCEFastPIDReco.cc
+++ b/FastPID/ECCEFastPIDReco.cc
@@ -17,9 +17,9 @@
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>  // for PHNode
+#include <phool/PHNode.h> // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>  // for PHObject
+#include <phool/PHObject.h> // for PHObject
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
@@ -37,26 +37,23 @@ using namespace std;
 ECCEFastPIDReco::ECCEFastPIDReco(ECCEFastPIDMap *map,
                                  EICPIDDefs::PIDDetector det,
                                  const std::string &name)
-  : SubsysReco(name)
-  , m_pidmap(map)
-  , m_PIDDetector(det)
-{
-  if (!map)
-  {
-    std::cout << "ECCEFastPIDReco::ECCEFastPIDReco(): Fatal Error missing ECCEFastPIDMap" << std::endl;
+    : SubsysReco(name), m_pidmap(map), m_PIDDetector(det) {
+  if (!map) {
+    std::cout << "ECCEFastPIDReco::ECCEFastPIDReco(): Fatal Error missing "
+                 "ECCEFastPIDMap"
+              << std::endl;
     exit(1);
   }
 }
 
 //____________________________________________________________________________..
-ECCEFastPIDReco::~ECCEFastPIDReco()
-{
-  if (m_pidmap) delete m_pidmap;
+ECCEFastPIDReco::~ECCEFastPIDReco() {
+  if (m_pidmap)
+    delete m_pidmap;
 }
 
 //____________________________________________________________________________..
-int ECCEFastPIDReco::Init(PHCompositeNode *topNode)
-{
+int ECCEFastPIDReco::Init(PHCompositeNode *topNode) {
   // many fast PID import code used gRandom.
   // Quick fix to override seed.
   // Should switch well controlled gsl_rng
@@ -66,50 +63,50 @@ int ECCEFastPIDReco::Init(PHCompositeNode *topNode)
 }
 
 //____________________________________________________________________________..
-int ECCEFastPIDReco::InitRun(PHCompositeNode *topNode)
-{
-  m_SvtxTrackMap = findNode::getClass<SvtxTrackMap>(topNode, m_TrackmapNodeName);
-  if (!m_SvtxTrackMap)
-  {
-    cout << __PRETTY_FUNCTION__ <<" "<<Name()<< ": fatal error missing node " << m_TrackmapNodeName << endl;
+int ECCEFastPIDReco::InitRun(PHCompositeNode *topNode) {
+  m_SvtxTrackMap =
+      findNode::getClass<SvtxTrackMap>(topNode, m_TrackmapNodeName);
+  if (!m_SvtxTrackMap) {
+    cout << __PRETTY_FUNCTION__ << " " << Name()
+         << ": fatal error missing node " << m_TrackmapNodeName << endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
   /// G4 truth particle node
-  m_truthInfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
-  if (!m_truthInfo)
-  {
-    cout << __PRETTY_FUNCTION__<<" "<<Name()
-         << ": PHG4TruthInfoContainer node is missing, can't collect G4 truth particles"
+  m_truthInfo =
+      findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  if (!m_truthInfo) {
+    cout << __PRETTY_FUNCTION__ << " " << Name()
+         << ": PHG4TruthInfoContainer node is missing, can't collect G4 truth "
+            "particles"
          << endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  if (m_matchG4Hit)
-  {
+  if (m_matchG4Hit) {
     m_g4hits = findNode::getClass<PHG4HitContainer>(topNode, m_G4HitNodeName);
-    if (!m_g4hits)
-    {
-      cout << __PRETTY_FUNCTION__<<" "<<Name()
-           << ": PHG4HitContainer " << m_G4HitNodeName << " node is missing, can't match to g4hits"
+    if (!m_g4hits) {
+      cout << __PRETTY_FUNCTION__ << " " << Name() << ": PHG4HitContainer "
+           << m_G4HitNodeName << " node is missing, can't match to g4hits"
            << endl;
       return Fun4AllReturnCodes::ABORTRUN;
     }
   }
 
-  m_EICPIDParticleContainer = findNode::getClass<EICPIDParticleContainer>(topNode, m_EICPIDParticleMapNodeName);
-  if (!m_EICPIDParticleContainer)
-  {
+  m_EICPIDParticleContainer = findNode::getClass<EICPIDParticleContainer>(
+      topNode, m_EICPIDParticleMapNodeName);
+  if (!m_EICPIDParticleContainer) {
     m_EICPIDParticleContainer = new EICPIDParticleContainer;
 
-    PHIODataNode<PHObject> *pid_node = new PHIODataNode<PHObject>(m_EICPIDParticleContainer, m_EICPIDParticleMapNodeName, "PHObject");
+    PHIODataNode<PHObject> *pid_node = new PHIODataNode<PHObject>(
+        m_EICPIDParticleContainer, m_EICPIDParticleMapNodeName, "PHObject");
 
     PHNodeIterator iter(topNode);
-    PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+    PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(
+        iter.findFirst("PHCompositeNode", "DST"));
     assert(dstNode);
     dstNode->addNode(pid_node);
-    if (Verbosity() > 0)
-    {
+    if (Verbosity() > 0) {
       cout << m_EICPIDParticleMapNodeName << " node added" << endl;
     }
   }
@@ -118,34 +115,29 @@ int ECCEFastPIDReco::InitRun(PHCompositeNode *topNode)
 }
 
 //____________________________________________________________________________..
-int ECCEFastPIDReco::process_event(PHCompositeNode *topNode)
-{
+int ECCEFastPIDReco::process_event(PHCompositeNode *topNode) {
   assert(m_SvtxTrackMap);
   assert(m_EICPIDParticleContainer);
 
-  if (Verbosity() >= 1)
-  {
-    cout << __PRETTY_FUNCTION__ <<" "<<Name()<< ": m_SvtxTrackMap = ";
+  if (Verbosity() >= 1) {
+    cout << __PRETTY_FUNCTION__ << " " << Name() << ": m_SvtxTrackMap = ";
     m_SvtxTrackMap->identify();
   }
 
-  for (const auto &track_pair : *m_SvtxTrackMap)
-  {
+  for (const auto &track_pair : *m_SvtxTrackMap) {
     const SvtxTrack *track = track_pair.second;
     assert(track);
 
-    const SvtxTrack_FastSim *fasttrack = dynamic_cast<const SvtxTrack_FastSim *>(track);
+    const SvtxTrack_FastSim *fasttrack =
+        dynamic_cast<const SvtxTrack_FastSim *>(track);
 
-    if (!fasttrack)
-    {
-      if (Verbosity())
-      {
-        cout << __PRETTY_FUNCTION__ <<" "<<Name()<< " : ignore none SvtxTrack_FastSim track: ";
+    if (!fasttrack) {
+      if (Verbosity()) {
+        cout << __PRETTY_FUNCTION__ << " " << Name()
+             << " : ignore none SvtxTrack_FastSim track: ";
         track->identify();
       }
-    }
-    else
-    {  // process track
+    } else { // process track
 
       assert(m_truthInfo);
 
@@ -155,102 +147,102 @@ int ECCEFastPIDReco::process_event(PHCompositeNode *topNode)
 
       const int truth_pid = g4particle->get_pid();
 
-      CLHEP::Hep3Vector momentum(
-          g4particle->get_px(),
-          g4particle->get_py(),
-          g4particle->get_pz());
+      CLHEP::Hep3Vector momentum(g4particle->get_px(), g4particle->get_py(),
+                                 g4particle->get_pz());
 
       bool matched = false;
-      if (m_matchG4Hit)
-      {
+      if (m_matchG4Hit) {
         matched = false;
 
         // find hit in detector vol.
         assert(m_g4hits);
 
         auto hit_range = m_g4hits->getHits();
-        for (auto hititer = hit_range.first; hititer != hit_range.second; ++hititer)
-        {
+        for (auto hititer = hit_range.first; hititer != hit_range.second;
+             ++hititer) {
           const PHG4Hit *hit = hititer->second;
           assert(hit);
 
           // match first hit of track in PID detector:
-          if (hit->get_trkid() == g4particle->get_track_id())
-          {
-            if (Verbosity() >= 2)
-            {
-              cout << __PRETTY_FUNCTION__<<" "<<Name() << " Named " << Name() << " with hits " << m_G4HitNodeName << ": matching track ";
+          if (hit->get_trkid() == g4particle->get_track_id()) {
+            if (Verbosity() >= 2) {
+              cout << __PRETTY_FUNCTION__ << " " << Name() << " Named "
+                   << Name() << " with hits " << m_G4HitNodeName
+                   << ": matching track ";
               fasttrack->identify();
               cout << "with particle: ";
               g4particle->identify();
               cout << "with hit: ";
               hit->identify();
-              cout << "Result in momentum of " << momentum.mag() << "GeV/c at eta = " << momentum.eta() << endl;
+              cout << "Result in momentum of " << momentum.mag()
+                   << "GeV/c at eta = " << momentum.eta() << endl;
             }
 
             matched = true;
 
             break;
           }
-        }  // for
+        } // for
 
-        if (not matched)
-        {
-          if (Verbosity() >= 2)
-          {
-            cout << __PRETTY_FUNCTION__ <<" "<<Name()<< " Named " << Name() << " did NOT match hits in "
-                 << m_G4HitNodeName << " with track ";
+        if (not matched) {
+          if (Verbosity() >= 2) {
+            cout << __PRETTY_FUNCTION__ << " " << Name() << " Named " << Name()
+                 << " did NOT match hits in " << m_G4HitNodeName
+                 << " with track ";
             fasttrack->identify();
             cout << "with particle: ";
             g4particle->identify();
           }
         }
-      }  //       if (m_matchG4Hit)
-      else
-      {
-        if (Verbosity() >= 2)
-        {
-          cout << __PRETTY_FUNCTION__<<" "<<Name() << " Named " << Name()
-              << " with hits " << m_G4HitNodeName << ": matching track ";
+      } //       if (m_matchG4Hit)
+      else {
+        if (Verbosity() >= 2) {
+          cout << __PRETTY_FUNCTION__ << " " << Name() << " Named " << Name()
+               << " with hits " << m_G4HitNodeName << ": matching track ";
           fasttrack->identify();
           cout << "with particle: ";
           g4particle->identify();
-          cout << "Result in momentum of " << momentum.mag() << "GeV/c at eta = " << momentum.eta() << endl;
+          cout << "Result in momentum of " << momentum.mag()
+               << "GeV/c at eta = " << momentum.eta() << endl;
         }
         matched = true;
       }
 
-      auto pid_iter = m_EICPIDParticleContainer->findOrAddPIDParticle(fasttrack->get_id());
+      auto pid_iter =
+          m_EICPIDParticleContainer->findOrAddPIDParticle(fasttrack->get_id());
       EICPIDParticle *pidparticle = pid_iter->second;
       assert(pidparticle);
 
       pidparticle->set_property(EICPIDParticle::Truth_PID, truth_pid);
-      pidparticle->set_property(EICPIDParticle::Truth_momentum, (float) momentum.mag());
-      pidparticle->set_property(EICPIDParticle::Truth_eta, (float) momentum.eta());
+      pidparticle->set_property(EICPIDParticle::Truth_momentum,
+                                (float)momentum.mag());
+      pidparticle->set_property(EICPIDParticle::Truth_eta,
+                                (float)momentum.eta());
 
       assert(m_pidmap);
 
-      if (matched)
-      {
+      if (matched) {
         ECCEFastPIDMap::PIDCandidate_LogLikelihood_map ll_map =
-            m_pidmap->getFastSmearLogLikelihood(truth_pid, momentum.mag(), momentum.theta());
+            m_pidmap->getFastSmearLogLikelihood(truth_pid, momentum.mag(),
+                                                momentum.theta());
 
         for (const auto &pair : ll_map)
-          pidparticle->set_LogLikelyhood(pair.first, m_PIDDetector, pair.second);
+          pidparticle->set_LogLikelyhood(pair.first, m_PIDDetector,
+                                         pair.second);
       }
 
-      if (Verbosity() >= 2)
-      {
+      if (Verbosity() >= 2) {
         pidparticle->identify();
       }
     }
   }
 
-  if (Verbosity())
-  {
-    cout << __PRETTY_FUNCTION__ <<" "<<Name()<< " : done processing from trackmap ";
+  if (Verbosity()) {
+    cout << __PRETTY_FUNCTION__ << " " << Name()
+         << " : done processing from trackmap ";
     m_SvtxTrackMap->identify();
-    cout << __PRETTY_FUNCTION__ <<" "<<Name()<< " : produced EICPIDParticleContainer ";
+    cout << __PRETTY_FUNCTION__ << " " << Name()
+         << " : produced EICPIDParticleContainer ";
     m_EICPIDParticleContainer->identify();
   }
 
@@ -258,7 +250,6 @@ int ECCEFastPIDReco::process_event(PHCompositeNode *topNode)
 }
 
 //____________________________________________________________________________..
-int ECCEFastPIDReco::End(PHCompositeNode *topNode)
-{
+int ECCEFastPIDReco::End(PHCompositeNode *topNode) {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/FastPID/ECCEFastPIDReco.cc
+++ b/FastPID/ECCEFastPIDReco.cc
@@ -10,6 +10,7 @@
 #include <eicpidbase/EICPIDParticleContainer.h>
 
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 
@@ -23,16 +24,24 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
+#include <CLHEP/Vector/ThreeVector.h>
+
 #include <cassert>
 #include <iostream>
 
 using namespace std;
 
 //____________________________________________________________________________..
-ECCEFastPIDReco::ECCEFastPIDReco(const std::string &name)
+ECCEFastPIDReco::ECCEFastPIDReco(ECCEFastPIDMap *map,
+                                 const std::string &name)
   : SubsysReco(name)
+  , m_pidmap(map)
 {
-  std::cout << "ECCEFastPIDReco::ECCEFastPIDReco(const std::string &name) Calling ctor" << std::endl;
+  if (!map)
+  {
+    std::cout << "ECCEFastPIDReco::ECCEFastPIDReco(): Fatal Error missing ECCEFastPIDMap" << std::endl;
+    exit(1);
+  }
 }
 
 //____________________________________________________________________________..
@@ -57,13 +66,39 @@ int ECCEFastPIDReco::InitRun(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
+  /// G4 truth particle node
+  m_truthInfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  if (!m_truthInfo)
+  {
+    cout << __PRETTY_FUNCTION__
+         << ": PHG4TruthInfoContainer node is missing, can't collect G4 truth particles"
+         << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  if (m_matchG4Hit)
+  {
+    m_g4hits = findNode::getClass<PHG4HitContainer>(topNode, m_G4HitNodeName);
+    if (!m_g4hits)
+    {
+      cout << __PRETTY_FUNCTION__
+           << ": PHG4HitContainer " << m_G4HitNodeName << " node is missing, can't match to g4hits"
+           << endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+  }
+
   m_EICPIDParticleContainer = findNode::getClass<EICPIDParticleContainer>(topNode, m_EICPIDParticleMapNodeName);
   if (!m_EICPIDParticleContainer)
   {
     m_EICPIDParticleContainer = new EICPIDParticleContainer;
 
     PHIODataNode<PHObject> *pid_node = new PHIODataNode<PHObject>(m_EICPIDParticleContainer, m_EICPIDParticleMapNodeName, "PHObject");
-    topNode->addNode(pid_node);
+
+    PHNodeIterator iter(topNode);
+    PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+    assert(dstNode);
+    dstNode->addNode(pid_node);
     if (Verbosity() > 0)
     {
       cout << m_EICPIDParticleMapNodeName << " node added" << endl;
@@ -78,6 +113,12 @@ int ECCEFastPIDReco::process_event(PHCompositeNode *topNode)
 {
   assert(m_SvtxTrackMap);
   assert(m_EICPIDParticleContainer);
+
+  if (Verbosity() >= 1)
+  {
+    cout << __PRETTY_FUNCTION__ << ": m_SvtxTrackMap = ";
+    m_SvtxTrackMap->identify();
+  }
 
   for (const auto &track_pair : *m_SvtxTrackMap)
   {
@@ -96,11 +137,92 @@ int ECCEFastPIDReco::process_event(PHCompositeNode *topNode)
     }
     else
     {  // process track
-      auto iter = m_EICPIDParticleContainer->findOrAddPIDParticle(track->get_id());
 
-      EICPIDParticle *pidparticle = iter->second;
+      assert(m_truthInfo);
 
+      PHG4Particle *g4particle =
+          m_truthInfo->GetParticle(fasttrack->get_truth_track_id());
+      assert(g4particle);
+
+      const int truth_pid = g4particle->get_pid();
+
+      CLHEP::Hep3Vector momentum;
+      if (m_matchG4Hit)
+      {
+        // find hit in detector vol.
+        assert(m_g4hits);
+
+        auto hit_range = m_g4hits->getHits();
+        for (auto hititer = hit_range.first; hititer != hit_range.second; ++hititer)
+        {
+          const PHG4Hit *hit = hititer->second;
+          assert(hit);
+
+          // match first hit of track in PID detector:
+          if (hit->get_trkid() == g4particle->get_track_id())
+          {
+            momentum.set(
+                hit->get_px(0),
+                hit->get_py(0),
+                hit->get_pz(0));
+
+            if (Verbosity() >= 2)
+            {
+              cout << __PRETTY_FUNCTION__ << " Named " << Name() << " with hits " << m_G4HitNodeName << ": matching track ";
+              fasttrack->identify();
+              cout << "with particle: ";
+              g4particle->identify();
+              cout << "with hit: ";
+              hit->identify();
+              cout << "Result in momentum of " << momentum.mag() << "GeV/c at eta = " << momentum.eta() << endl;
+            }
+
+            break;
+          }
+        }  // for
+
+        if (momentum.mag() == 0)
+        {
+          if (Verbosity() >= 2)
+          {
+            cout << __PRETTY_FUNCTION__ << " Named " << Name() << " did NOT match hits in "
+                 << m_G4HitNodeName << " with track ";
+            fasttrack->identify();
+            cout << "with particle: ";
+            g4particle->identify();
+          }
+        }
+      }
+      else
+      {
+        // use vertex kinematics
+        momentum.set(
+            g4particle->get_px(),
+            g4particle->get_py(),
+            g4particle->get_pz());
+      }
+
+      auto pid_iter = m_EICPIDParticleContainer->findOrAddPIDParticle(fasttrack->get_id());
+      EICPIDParticle *pidparticle = pid_iter->second;
       assert(pidparticle);
+
+      pidparticle->set_property(EICPIDParticle::Truth_PID, truth_pid);
+
+      assert(m_pidmap);
+
+      if (momentum.mag() > 0)
+      {
+        ECCEFastPIDMap::PIDCandidate_LogLikelihood_map ll_map =
+            m_pidmap->getFastSmearLogLikelihood(truth_pid, momentum.mag(), momentum.theta());
+
+        for (const auto &pair : ll_map)
+          pidparticle->set_LogLikelyhood(pair.first, EICPIDDefs::DIRC, pair.second);
+      }
+
+      if (Verbosity() >= 2)
+      {
+        pidparticle->identify();
+      }
     }
   }
 

--- a/FastPID/ECCEFastPIDReco.cc
+++ b/FastPID/ECCEFastPIDReco.cc
@@ -260,6 +260,5 @@ int ECCEFastPIDReco::process_event(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int ECCEFastPIDReco::End(PHCompositeNode *topNode)
 {
-  std::cout << "ECCEFastPIDReco::End(PHCompositeNode *topNode) This is the End..." << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/FastPID/ECCEFastPIDReco.h
+++ b/FastPID/ECCEFastPIDReco.h
@@ -1,0 +1,62 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef ECCEFASTPIDRECO_H
+#define ECCEFASTPIDRECO_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <eicpidbase/EICPIDDefs.h>
+
+#include <string>
+
+class PHCompositeNode;
+class ECCEFastPIDMap;
+class SvtxTrackMap;
+class EICPIDParticleContainer;
+
+class ECCEFastPIDReco : public SubsysReco
+{
+ public:
+  ECCEFastPIDReco(const std::string &name = "ECCEFastPIDReco");
+
+  virtual ~ECCEFastPIDReco();
+
+  /** Called during initialization.
+      Typically this is where you can book histograms, and e.g.
+      register them to Fun4AllServer (so they can be output to file
+      using Fun4AllServer::dumpHistos() method).
+   */
+  int Init(PHCompositeNode *topNode) override;
+
+  /** Called for first event when run number is known.
+      Typically this is where you may want to fetch data from
+      database, because you know the run number. A place
+      to book histograms which have to know the run number.
+   */
+  int InitRun(PHCompositeNode *topNode) override;
+
+  /** Called for each event.
+      This is where you do the real work.
+   */
+  int process_event(PHCompositeNode *topNode) override;
+
+  /// Called at the end of all processing.
+  int End(PHCompositeNode *topNode) override;
+
+  void setTrackmapNodeName(const std::string &name) { m_TrackmapNodeName = name; }
+
+  void setEICPIDParticleMapNodeName(const std::string &name) { m_EICPIDParticleMapNodeName = name; }
+
+ private:
+  bool m_matchG4Hit = false;
+
+  ECCEFastPIDMap *m_pidmap = nullptr;
+
+  std::string m_TrackmapNodeName = "SvtxTrackMap";
+  std::string m_EICPIDParticleMapNodeName = "EICPIDParticleMap";
+
+  SvtxTrackMap * m_SvtxTrackMap = nullptr;
+  EICPIDParticleContainer * m_EICPIDParticleContainer = nullptr;
+};
+
+#endif  // ECCEFASTPIDRECO_H

--- a/FastPID/ECCEFastPIDReco.h
+++ b/FastPID/ECCEFastPIDReco.h
@@ -13,11 +13,14 @@ class PHCompositeNode;
 class ECCEFastPIDMap;
 class SvtxTrackMap;
 class EICPIDParticleContainer;
+class PHG4TruthInfoContainer;
+class PHG4HitContainer;
 
 class ECCEFastPIDReco : public SubsysReco
 {
  public:
-  ECCEFastPIDReco(const std::string &name = "ECCEFastPIDReco");
+  ECCEFastPIDReco(ECCEFastPIDMap *map,
+                  const std::string &name = "ECCEFastPIDReco");
 
   virtual ~ECCEFastPIDReco();
 
@@ -47,16 +50,26 @@ class ECCEFastPIDReco : public SubsysReco
 
   void setEICPIDParticleMapNodeName(const std::string &name) { m_EICPIDParticleMapNodeName = name; }
 
+  void setMatchG4Hit(const std::string &g4hit_node_name)
+  {
+    m_matchG4Hit = true;
+    m_G4HitNodeName = g4hit_node_name;
+  }
+
  private:
   bool m_matchG4Hit = false;
 
-  ECCEFastPIDMap *m_pidmap = nullptr;
+  std::string m_G4HitNodeName = "Uninitialized";
 
-  std::string m_TrackmapNodeName = "SvtxTrackMap";
+  ECCEFastPIDMap *m_pidmap;
+
+  std::string m_TrackmapNodeName = "TrackMap";
   std::string m_EICPIDParticleMapNodeName = "EICPIDParticleMap";
 
-  SvtxTrackMap * m_SvtxTrackMap = nullptr;
-  EICPIDParticleContainer * m_EICPIDParticleContainer = nullptr;
+  SvtxTrackMap *m_SvtxTrackMap = nullptr;
+  EICPIDParticleContainer *m_EICPIDParticleContainer = nullptr;
+  PHG4TruthInfoContainer *m_truthInfo = nullptr;
+  PHG4HitContainer *m_g4hits = nullptr;
 };
 
 #endif  // ECCEFASTPIDRECO_H

--- a/FastPID/ECCEFastPIDReco.h
+++ b/FastPID/ECCEFastPIDReco.h
@@ -20,6 +20,7 @@ class ECCEFastPIDReco : public SubsysReco
 {
  public:
   ECCEFastPIDReco(ECCEFastPIDMap *map,
+                  EICPIDDefs::PIDDetector det,
                   const std::string &name = "ECCEFastPIDReco");
 
   virtual ~ECCEFastPIDReco();
@@ -62,6 +63,7 @@ class ECCEFastPIDReco : public SubsysReco
   std::string m_G4HitNodeName = "Uninitialized";
 
   ECCEFastPIDMap *m_pidmap;
+  EICPIDDefs::PIDDetector m_PIDDetector;
 
   std::string m_TrackmapNodeName = "TrackMap";
   std::string m_EICPIDParticleMapNodeName = "EICPIDParticleMap";

--- a/FastPID/ECCEFastPIDReco.h
+++ b/FastPID/ECCEFastPIDReco.h
@@ -16,11 +16,9 @@ class EICPIDParticleContainer;
 class PHG4TruthInfoContainer;
 class PHG4HitContainer;
 
-class ECCEFastPIDReco : public SubsysReco
-{
- public:
-  ECCEFastPIDReco(ECCEFastPIDMap *map,
-                  EICPIDDefs::PIDDetector det,
+class ECCEFastPIDReco : public SubsysReco {
+public:
+  ECCEFastPIDReco(ECCEFastPIDMap *map, EICPIDDefs::PIDDetector det,
                   const std::string &name = "ECCEFastPIDReco");
 
   virtual ~ECCEFastPIDReco();
@@ -47,17 +45,20 @@ class ECCEFastPIDReco : public SubsysReco
   /// Called at the end of all processing.
   int End(PHCompositeNode *topNode) override;
 
-  void setTrackmapNodeName(const std::string &name) { m_TrackmapNodeName = name; }
+  void setTrackmapNodeName(const std::string &name) {
+    m_TrackmapNodeName = name;
+  }
 
-  void setEICPIDParticleMapNodeName(const std::string &name) { m_EICPIDParticleMapNodeName = name; }
+  void setEICPIDParticleMapNodeName(const std::string &name) {
+    m_EICPIDParticleMapNodeName = name;
+  }
 
-  void setMatchG4Hit(const std::string &g4hit_node_name)
-  {
+  void setMatchG4Hit(const std::string &g4hit_node_name) {
     m_matchG4Hit = true;
     m_G4HitNodeName = g4hit_node_name;
   }
 
- private:
+private:
   bool m_matchG4Hit = false;
 
   std::string m_G4HitNodeName = "Uninitialized";
@@ -74,4 +75,4 @@ class ECCEFastPIDReco : public SubsysReco
   PHG4HitContainer *m_g4hits = nullptr;
 };
 
-#endif  // ECCEFASTPIDRECO_H
+#endif // ECCEFASTPIDRECO_H

--- a/FastPID/ECCEdRICHFastPIDMap.cc
+++ b/FastPID/ECCEdRICHFastPIDMap.cc
@@ -1,0 +1,185 @@
+// $Id: $
+
+/*!
+ * \file ECCEdRICHFastPIDMap.cc
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "ECCEdRICHFastPIDMap.h"
+
+#include <TF1.h>
+#include <TFile.h>
+#include <TH2F.h>
+#include <TMath.h>
+#include <TRandom.h>
+#include <TVector3.h>
+
+#include <cassert>
+#include <cmath>
+
+ECCEdRICHFastPIDMap::ECCEdRICHFastPIDMap()
+{
+  int barid = 0;
+
+  fMass[0] = 0.000511;
+  fMass[1] = 0.105658;
+  fMass[2] = 0.139570;
+  fMass[3] = 0.49368;
+  fMass[4] = 0.938272;
+
+  // multiple scattering for 17 mm thick radiator at 30 deg
+  fMs_mom = new TF1("", "expo(0)+expo(2)+expo(4)");
+  fMs_mom->SetParameters(4.40541e+00, -5.52436e+00, 2.35058e+00, -1.02703e+00, 9.55032e-01,
+                         -1.48500e-01);
+  // fMs_mom->SetParameters(9.39815e-01, -1.48243e-01, 4.69733e+00, -4.33960e+00, 2.19745e+00,
+  //                       -9.68617e-01);
+
+  fMs_thickness = new TF1("", "pol1");
+
+  if (barid == 1)
+    fMs_thickness->SetParameters(3.5, 0.0214286);  // 10 mm bar
+  else
+    fMs_thickness->SetParameters(4.5, 0.0357143);  // 17 mm bar
+
+  TF1 *fMs_thickness_17 = new TF1("", "pol1");
+  fMs_thickness_17->SetParameters(4.5, 0.0357143);  // 17 mm bar
+  fMs_thickness_max = fMs_thickness_17->Eval(70);
+}
+
+ECCEdRICHFastPIDMap::~ECCEdRICHFastPIDMap()
+{
+}
+
+ECCEdRICHFastPIDMap::PIDCandidate_LogLikelihood_map
+ECCEdRICHFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta_rad) const
+{
+  assert(fTrrMap);
+
+  // preprocessing
+  double theta = theta_rad * TMath::RadToDeg();
+  truth_pid = abs(truth_pid);
+  // track_err - error assosiated with track direction [mrad]
+  double track_err = 0.326;
+  double p = momentum;
+
+  PIDCandidate_LogLikelihood_map ll_map;
+
+  // copy from DrcPidFast::
+  // pdg - Particle Data Group code of the particle
+  // mom - 3-momentum of the particle [GeV/c]
+  // track_err - error assosiated with track direction [mrad]
+  //  DrcPidInfo GetInfo(int pdg, TVector3 mom, double track_err = 0);
+
+  const int max = 5;
+  DrcPidInfo info;
+  int pid = get_pid(truth_pid);
+
+  if (pid == 0)
+  {
+    return ll_map;
+  }
+
+  // set default values
+  for (int i = 0; i < max; i++)
+  {
+    info.probability[i] = 0.25;
+    info.sigma[i] = 100;
+  }
+  info.cangle = 0;
+  info.cctr = 0;
+
+  // check range
+  //  if (theta < 19.99 || theta > 160.01){
+  //    std::cout<<"theta out of [20,160] deg range: "<<theta<<std::endl;
+  //  }
+
+  double ms_mom_err = fMs_mom->Eval(p);  // vector deviation after radiator
+
+  double alpha = (theta < 90) ? 90 - theta : theta - 90;
+  double ms_thick_frac = fMs_thickness->Eval(alpha) / fMs_thickness_max;
+
+  // 0.31 for averaging direction vector over the radiator thickness
+  double ms_err = 0.31 * ms_mom_err * ms_thick_frac;
+
+  // ctr map is for theta = [25,153] and p = [0,10] GeV/c
+  if (theta < 25) theta = 25;
+  if (theta > 153) theta = 153;
+  if (p > 10) p = 10;
+
+  int bin = fTrrMap->FindBin(theta, p);
+  double ctr = fTrrMap->GetBinContent(bin);  // Cherenkov track resolution [mrad]
+  double cctr = sqrt(ctr * ctr + track_err * track_err + ms_err * ms_err) *
+                0.001;  // combined Cherenkov track resolution[rad]
+
+  // 1.46907 - fused silica
+  double true_cangle = acos(sqrt(p * p + fMass[pid] * fMass[pid]) / p / 1.46907);
+  true_cangle += gRandom->Gaus(0, cctr);
+
+  // return default values if momentum below Cherenkov threshold (true_cangle is NaN)
+  if (isnan(true_cangle)) return ll_map;
+
+  double cangle, sum = 0, fsum = 0;
+  double delta[max] = {0};  //, probability[max] = {0};
+
+  for (int i = 0; i < max; i++)
+  {
+    cangle = acos(sqrt(p * p + fMass[i] * fMass[i]) / p / 1.46907);
+    if (isnan(cangle))
+    {
+      ll_map[get_PIDCandidate(i)] = -100;  // set non-firing particle candidate to low probability
+      continue;
+    }
+    delta[i] = fabs(cangle - true_cangle);
+    sum += delta[i];
+    info.sigma[i] = (cangle - true_cangle) / cctr;
+    if (i == pid) info.cangle = cangle;
+
+    ll_map[get_PIDCandidate(i)] = -0.5 * info.sigma[i] * info.sigma[i];
+  }
+  // normalization
+  for (int i = 0; i < max; i++)
+  {
+    if (delta[i] > 0) info.probability[i] = sum / delta[i];
+    fsum += info.probability[i];
+  }
+  for (int i = 0; i < max; i++) info.probability[i] /= fsum;
+  info.cctr = cctr;
+
+  return ll_map;
+}
+
+void ECCEdRICHFastPIDMap::ReadMap(const std::string &name)
+{
+  TFile *file = TFile::Open(name.c_str());
+  assert(file);
+  //  fTrrMap = new TH2F();
+  file->GetObject("htrr", fTrrMap);
+  assert(fTrrMap);
+}
+
+int ECCEdRICHFastPIDMap::get_pid(int pdg)
+{
+  int pid = 0;
+  if (pdg == 11) pid = 0;    // e
+  if (pdg == 13) pid = 1;    // mu
+  if (pdg == 211) pid = 2;   // pi
+  if (pdg == 321) pid = 3;   // K
+  if (pdg == 2212) pid = 4;  // p
+  return pid;
+}
+
+EICPIDDefs::PIDCandidate ECCEdRICHFastPIDMap::get_PIDCandidate(int pid)
+{
+  EICPIDDefs::PIDCandidate id = EICPIDDefs::InvalidCandiate;
+  if (pid == 0) id = EICPIDDefs::ElectronCandiate;  // e
+  if (pid == 1) id = EICPIDDefs::MuonCandiate;      // mu
+  if (pid == 2) id = EICPIDDefs::PionCandiate;      // pi
+  if (pid == 3) id = EICPIDDefs::KaonCandiate;      // K
+  if (pid == 4) id = EICPIDDefs::ProtonCandiate;    // p
+  assert(id != EICPIDDefs::InvalidCandiate);
+
+  return id;
+}

--- a/FastPID/ECCEdRICHFastPIDMap.cc
+++ b/FastPID/ECCEdRICHFastPIDMap.cc
@@ -12,6 +12,7 @@
 
 #include <TF1.h>
 #include <TFile.h>
+#include <TGraph.h>
 #include <TH2F.h>
 #include <TMath.h>
 #include <TRandom.h>
@@ -19,34 +20,10 @@
 
 #include <cassert>
 #include <cmath>
+#include <iostream>
 
 ECCEdRICHFastPIDMap::ECCEdRICHFastPIDMap()
 {
-  int barid = 0;
-
-  fMass[0] = 0.000511;
-  fMass[1] = 0.105658;
-  fMass[2] = 0.139570;
-  fMass[3] = 0.49368;
-  fMass[4] = 0.938272;
-
-  // multiple scattering for 17 mm thick radiator at 30 deg
-  fMs_mom = new TF1("", "expo(0)+expo(2)+expo(4)");
-  fMs_mom->SetParameters(4.40541e+00, -5.52436e+00, 2.35058e+00, -1.02703e+00, 9.55032e-01,
-                         -1.48500e-01);
-  // fMs_mom->SetParameters(9.39815e-01, -1.48243e-01, 4.69733e+00, -4.33960e+00, 2.19745e+00,
-  //                       -9.68617e-01);
-
-  fMs_thickness = new TF1("", "pol1");
-
-  if (barid == 1)
-    fMs_thickness->SetParameters(3.5, 0.0214286);  // 10 mm bar
-  else
-    fMs_thickness->SetParameters(4.5, 0.0357143);  // 17 mm bar
-
-  TF1 *fMs_thickness_17 = new TF1("", "pol1");
-  fMs_thickness_17->SetParameters(4.5, 0.0357143);  // 17 mm bar
-  fMs_thickness_max = fMs_thickness_17->Eval(70);
 }
 
 ECCEdRICHFastPIDMap::~ECCEdRICHFastPIDMap()
@@ -56,130 +33,186 @@ ECCEdRICHFastPIDMap::~ECCEdRICHFastPIDMap()
 ECCEdRICHFastPIDMap::PIDCandidate_LogLikelihood_map
 ECCEdRICHFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta_rad) const
 {
-  assert(fTrrMap);
-
-  // preprocessing
-  double theta = theta_rad * TMath::RadToDeg();
-  truth_pid = abs(truth_pid);
-  // track_err - error assosiated with track direction [mrad]
-  double track_err = 0.326;
-  double p = momentum;
+  assert(initialized);
 
   PIDCandidate_LogLikelihood_map ll_map;
 
-  // copy from DrcPidFast::
-  // pdg - Particle Data Group code of the particle
-  // mom - 3-momentum of the particle [GeV/c]
-  // track_err - error assosiated with track direction [mrad]
-  //  DrcPidInfo GetInfo(int pdg, TVector3 mom, double track_err = 0);
+  const int abs_truth_pid = abs(truth_pid);
+  const double eta = -log(tan(0.5 * theta_rad));
 
-  const int max = 5;
-  DrcPidInfo info;
-  int pid = get_pid(truth_pid);
-
-  if (pid == 0)
+  if (eta < etaMin() or eta > etaMax())
   {
+    // not processing out of acceptance tracks
+    if (Verbosity())
+      std::cout << __PRETTY_FUNCTION__ << " " << mName << ": not processing out of acceptance tracks eta = " << eta
+                << "  etaMin()  = " << etaMin()
+                << "  etaMax()  = " << etaMax()
+                << std::endl;
+
     return ll_map;
   }
 
-  // set default values
-  for (int i = 0; i < max; i++)
-  {
-    info.probability[i] = 0.25;
-    info.sigma[i] = 100;
-  }
-  info.cangle = 0;
-  info.cctr = 0;
+  const double Nsigma_piK = numSigma(eta, momentum, pi_k);
+  const double Nsigma_Kp = numSigma(eta, momentum, k_p);
 
-  // check range
-  //  if (theta < 19.99 || theta > 160.01){
-  //    std::cout<<"theta out of [20,160] deg range: "<<theta<<std::endl;
-  //  }
+  if (Verbosity())
+    std::cout << __PRETTY_FUNCTION__ << " " << mName << ": processing tracks momentum = " << momentum
+              << " eta = " << eta
+              << " Nsigma_piK = " << Nsigma_piK << " Nsigma_Kp = " << Nsigma_Kp
+              << std::endl;
 
-  double ms_mom_err = fMs_mom->Eval(p);  // vector deviation after radiator
+  const double pion_sigma_space_ring_radius = +Nsigma_piK;
+  const double kaon_sigma_space_ring_radius = 0;
+  const double proton_sigma_space_ring_radius = -Nsigma_Kp;
 
-  double alpha = (theta < 90) ? 90 - theta : theta - 90;
-  double ms_thick_frac = fMs_thickness->Eval(alpha) / fMs_thickness_max;
+  double sigma_space_ring_radius = gRandom->Gaus(0, 1);
+  if (abs_truth_pid == EICPIDDefs::PionCandiate)
+    sigma_space_ring_radius += pion_sigma_space_ring_radius;
+  else if (abs_truth_pid == EICPIDDefs::KaonCandiate)
+    sigma_space_ring_radius += kaon_sigma_space_ring_radius;
+  else if (abs_truth_pid == EICPIDDefs::ProtonCandiate)
+    sigma_space_ring_radius += proton_sigma_space_ring_radius;
 
-  // 0.31 for averaging direction vector over the radiator thickness
-  double ms_err = 0.31 * ms_mom_err * ms_thick_frac;
-
-  // ctr map is for theta = [25,153] and p = [0,10] GeV/c
-  if (theta < 25) theta = 25;
-  if (theta > 153) theta = 153;
-  if (p > 10) p = 10;
-
-  int bin = fTrrMap->FindBin(theta, p);
-  double ctr = fTrrMap->GetBinContent(bin);  // Cherenkov track resolution [mrad]
-  double cctr = sqrt(ctr * ctr + track_err * track_err + ms_err * ms_err) *
-                0.001;  // combined Cherenkov track resolution[rad]
-
-  // 1.46907 - fused silica
-  double true_cangle = acos(sqrt(p * p + fMass[pid] * fMass[pid]) / p / 1.46907);
-  true_cangle += gRandom->Gaus(0, cctr);
-
-  // return default values if momentum below Cherenkov threshold (true_cangle is NaN)
-  if (isnan(true_cangle)) return ll_map;
-
-  double cangle, sum = 0, fsum = 0;
-  double delta[max] = {0};  //, probability[max] = {0};
-
-  for (int i = 0; i < max; i++)
-  {
-    cangle = acos(sqrt(p * p + fMass[i] * fMass[i]) / p / 1.46907);
-    if (isnan(cangle))
-    {
-      ll_map[get_PIDCandidate(i)] = -100;  // set non-firing particle candidate to low probability
-      continue;
-    }
-    delta[i] = fabs(cangle - true_cangle);
-    sum += delta[i];
-    info.sigma[i] = (cangle - true_cangle) / cctr;
-    if (i == pid) info.cangle = cangle;
-
-    ll_map[get_PIDCandidate(i)] = -0.5 * info.sigma[i] * info.sigma[i];
-  }
-  // normalization
-  for (int i = 0; i < max; i++)
-  {
-    if (delta[i] > 0) info.probability[i] = sum / delta[i];
-    fsum += info.probability[i];
-  }
-  for (int i = 0; i < max; i++) info.probability[i] /= fsum;
-  info.cctr = cctr;
+  ll_map[EICPIDDefs::PionCandiate] = -0.5 * pow(sigma_space_ring_radius - pion_sigma_space_ring_radius, 2);
+  ll_map[EICPIDDefs::KaonCandiate] = -0.5 * pow(sigma_space_ring_radius - kaon_sigma_space_ring_radius, 2);
+  ll_map[EICPIDDefs::ProtonCandiate] = -0.5 * pow(sigma_space_ring_radius - proton_sigma_space_ring_radius, 2);
 
   return ll_map;
 }
 
-void ECCEdRICHFastPIDMap::ReadMap(const std::string &name)
+double
+ECCEdRICHFastPIDMap::etaMin() const
 {
-  TFile *file = TFile::Open(name.c_str());
-  assert(file);
-  //  fTrrMap = new TH2F();
-  file->GetObject("htrr", fTrrMap);
-  assert(fTrrMap);
+  switch (mType)
+  {
+  case kBarrel:
+    return -log(tan(atan2(mRadius, -mLength) * 0.5));
+  case kForward:
+    return -log(tan(atan2(mRadiusOut, mPositionZ) * 0.5));
+  }
+  return 0.;
 }
 
-int ECCEdRICHFastPIDMap::get_pid(int pdg)
+double
+ECCEdRICHFastPIDMap::etaMax() const
 {
-  int pid = 0;
-  if (pdg == 11) pid = 0;    // e
-  if (pdg == 13) pid = 1;    // mu
-  if (pdg == 211) pid = 2;   // pi
-  if (pdg == 321) pid = 3;   // K
-  if (pdg == 2212) pid = 4;  // p
-  return pid;
+  switch (mType)
+  {
+  case kBarrel:
+    return -log(tan(atan2(mRadius, mLength) * 0.5));
+  case kForward:
+    return -log(tan(atan2(mRadiusIn, mPositionZ) * 0.5));
+  }
+  return 0.;
 }
 
-EICPIDDefs::PIDCandidate ECCEdRICHFastPIDMap::get_PIDCandidate(int pid)
+void ECCEdRICHFastPIDMap::dualRICH_aerogel()
 {
-  EICPIDDefs::PIDCandidate id = EICPIDDefs::InvalidCandiate;
-  if (pid == 0) id = EICPIDDefs::ElectronCandiate;  // e
-  if (pid == 1) id = EICPIDDefs::MuonCandiate;      // mu
-  if (pid == 2) id = EICPIDDefs::PionCandiate;      // pi
-  if (pid == 3) id = EICPIDDefs::KaonCandiate;      // K
-  if (pid == 4) id = EICPIDDefs::ProtonCandiate;    // p
-  assert(id != EICPIDDefs::InvalidCandiate);
+  initialized = true;
+  setName("aerogel");
+  /** geometry **/
+  setType(kForward);
+  setRadiusIn(10.);    // [cm]
+  setRadiusOut(120.);  // [cm]
+  setPositionZ(250.);  // [cm]
+  /** radiator **/
+  setLength(4.);  // [cm]
+  setIndex(1.02);
+  /** overall photon-detection efficiency **/
+  setEfficiency(0.08);
+  /** single-photon angular resolution **/
+  double angle[5] = {5., 10., 15., 20., 25.};                                              // [deg]
+  double chromatic[5] = {0.00260572, 0.00223447, 0.00229996, 0.00237615, 0.00245689};      // [rad] from actual file
+  double emission[5] = {0.000658453, 0.000297004, 0.00014763, 0.000196477, 0.000596087};   // [rad] from actual file
+  double pixel[5] = {0.000502646, 0.000575427, 0.000551095, 0.000555055, 0.000564831};     // [rad] from actual file
+  double field[5] = {8.13634e-05, 6.41901e-05, 3.92289e-05, 9.76800e-05, 2.58328e-05};     // [rad] from actual file
+  double tracking[5] = {0.000350351, 0.000306691, 0.000376006, 0.000401814, 0.000389742};  // [rad] from actual file
+  setChromaticSigma(5, angle, chromatic);
+  setPositionSigma(5, angle, pixel);
+  setEmissionSigma(5, angle, emission);
+  setFieldSigma(5, angle, field);
+  setTrackingSigma(5, angle, tracking);
+}
 
-  return id;
+void ECCEdRICHFastPIDMap::dualRICH_C2F6()
+{
+  initialized = true;
+  setName("C2F6");
+  /** geometry **/
+  setType(kForward);
+  setRadiusIn(10.);    // [cm]
+  setRadiusOut(120.);  // [cm]
+  setPositionZ(250.);  // [cm]
+  /** radiator **/
+  setLength(160.);  // [cm]
+  setIndex(1.0008);
+  /** overall photon-detection efficiency **/
+  setEfficiency(0.15);
+  /** single-photon angular resolution **/
+  double angle[5] = {5., 10., 15., 20., 25.};                                               // [deg]
+  double chromatic[5] = {0.000516327, 0.000527914, 0.000525467, 0.000515349, 0.000489377};  // [rad] from actual file
+  double emission[5] = {0.001439090, 0.000718037, 0.000656786, 0.000946782, 0.001404630};   // [rad] from actual file
+  double pixel[5] = {0.000480520, 0.000533282, 0.000564187, 0.000577872, 0.000605236};      // [rad] from actual file
+  double field[5] = {8.60521e-05, 7.64798e-05, 0.000167358, 0.000475598, 0.000629863};      // [rad] from actual file
+  double tracking[5] = {0.000389136, 0.000328530, 0.000402517, 0.000417901, 0.000393391};   // [rad] from actual file
+  setChromaticSigma(5, angle, chromatic);
+  setPositionSigma(5, angle, pixel);
+  setEmissionSigma(5, angle, emission);
+  setFieldSigma(5, angle, field);
+  setTrackingSigma(5, angle, tracking);
+}
+
+double ECCEdRICHFastPIDMap::cherenkovAngleSigma(double eta, double p, double m) const
+{
+  auto theta = 2. * atan(exp(-eta)) * 57.295780;
+  auto chromatic = mChromaticSigma ? mChromaticSigma->Eval(theta) : 0.;
+  auto position = mPositionSigma ? mPositionSigma->Eval(theta) : 0.;
+  auto emission = mEmissionSigma ? mEmissionSigma->Eval(theta) : 0.;
+  auto field = mFieldSigma ? mFieldSigma->Eval(theta) : 0.;
+  auto tracking = mTrackingSigma ? mTrackingSigma->Eval(theta) : 0.;
+
+  // contributions that scale with number of detected photons
+  auto ndet = numberOfDetectedPhotons(cherenkovAngle(p, m));
+  auto sigma1 = sqrt(chromatic * chromatic +
+                     position * position +
+                     emission * emission +
+                     field * field +
+                     tracking * tracking);
+  // contributions that do not
+  auto sigma2 = 0.;
+  //
+  return sqrt(sigma1 * sigma1 / ndet + sigma2 * sigma2);
+};
+
+double ECCEdRICHFastPIDMap::numSigma(double eta, double p, ECCEdRICHFastPIDMap::type PID) const
+{
+  double mass1(0), mass2(0);
+  switch (PID)
+  {
+  case pi_k:
+    mass1 = mMassPion;
+    mass2 = mMassKaon;
+    break;
+  case k_p:
+    mass1 = mMassKaon;
+    mass2 = mMassProton;
+    break;
+  default:
+    assert(0);  // exit the code for logical error
+    exit(1);
+  }
+
+  double thr1 = cherenkovThreshold(mass1);
+  double thr2 = cherenkovThreshold(mass2);
+
+  /** both particles are above threshold **/
+  if (p > thr1 && p > thr2)
+    return (cherenkovAngle(p, mass1) - cherenkovAngle(p, mass2)) / cherenkovAngleSigma(eta, p, mass1);
+
+  /** lightest particle above threshold **/
+  if (mThresholdMode && p > thr1)
+    return (cherenkovAngle(thr2 + 0.001, mass1) - cherenkovAngle(thr2 + 0.001, mass2)) / cherenkovAngleSigma(eta, thr2 + 0.001, mass1);
+
+  /** none above threshold **/
+  return 0.;
 }

--- a/FastPID/ECCEdRICHFastPIDMap.cc
+++ b/FastPID/ECCEdRICHFastPIDMap.cc
@@ -205,10 +205,27 @@ double ECCEdRICHFastPIDMap::numSigma(double eta, double p, ECCEdRICHFastPIDMap::
   double thr1 = cherenkovThreshold(mass1);
   double thr2 = cherenkovThreshold(mass2);
 
+  if (Verbosity())
+    std::cout << __PRETTY_FUNCTION__ << " " << mName << ": processing tracks momentum = " << p
+              << " eta = " << eta
+              << " thr1 = " << thr1 << " thr2 = " << thr2
+              << std::endl;
+
   /** both particles are above threshold **/
   if (p > thr1 && p > thr2)
-    return (cherenkovAngle(p, mass1) - cherenkovAngle(p, mass2)) / cherenkovAngleSigma(eta, p, mass1);
+  {
 
+    if (Verbosity())
+      std::cout << __PRETTY_FUNCTION__ << " " << mName << ": processing tracks momentum = " << p
+                << " eta = " << eta
+                << " cherenkovAngle(p, mass1) = " << cherenkovAngle(p, mass1)
+                << "  cherenkovAngle(p, mass2)) = " <<  cherenkovAngle(p, mass2)
+                << "  cherenkovAngleSigma(eta, p, mass1) = " <<  cherenkovAngleSigma(eta, p, mass1)
+                << std::endl;
+
+
+    return (cherenkovAngle(p, mass1) - cherenkovAngle(p, mass2)) / cherenkovAngleSigma(eta, p, mass1);
+  }
   /** lightest particle above threshold **/
   if (mThresholdMode && p > thr1)
     return (cherenkovAngle(thr2 + 0.001, mass1) - cherenkovAngle(thr2 + 0.001, mass2)) / cherenkovAngleSigma(eta, thr2 + 0.001, mass1);

--- a/FastPID/ECCEdRICHFastPIDMap.cc
+++ b/FastPID/ECCEdRICHFastPIDMap.cc
@@ -2,7 +2,7 @@
 
 /*!
  * \file ECCEdRICHFastPIDMap.cc
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $
@@ -22,17 +22,14 @@
 #include <cmath>
 #include <iostream>
 
-ECCEdRICHFastPIDMap::ECCEdRICHFastPIDMap()
-{
-}
+ECCEdRICHFastPIDMap::ECCEdRICHFastPIDMap() {}
 
-ECCEdRICHFastPIDMap::~ECCEdRICHFastPIDMap()
-{
-}
+ECCEdRICHFastPIDMap::~ECCEdRICHFastPIDMap() {}
 
 ECCEdRICHFastPIDMap::PIDCandidate_LogLikelihood_map
-ECCEdRICHFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta_rad) const
-{
+ECCEdRICHFastPIDMap::getFastSmearLogLikelihood(int truth_pid,
+                                               const double momentum,
+                                               const double theta_rad) const {
   assert(initialized);
 
   PIDCandidate_LogLikelihood_map ll_map;
@@ -40,13 +37,12 @@ ECCEdRICHFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double momen
   const int abs_truth_pid = abs(truth_pid);
   const double eta = -log(tan(0.5 * theta_rad));
 
-  if (eta < etaMin() or eta > etaMax())
-  {
+  if (eta < etaMin() or eta > etaMax()) {
     // not processing out of acceptance tracks
     if (Verbosity())
-      std::cout << __PRETTY_FUNCTION__ << " " << mName << ": not processing out of acceptance tracks eta = " << eta
-                << "  etaMin()  = " << etaMin()
-                << "  etaMax()  = " << etaMax()
+      std::cout << __PRETTY_FUNCTION__ << " " << mName
+                << ": not processing out of acceptance tracks eta = " << eta
+                << "  etaMin()  = " << etaMin() << "  etaMax()  = " << etaMax()
                 << std::endl;
 
     return ll_map;
@@ -56,10 +52,10 @@ ECCEdRICHFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double momen
   const double Nsigma_Kp = numSigma(eta, momentum, k_p);
 
   if (Verbosity())
-    std::cout << __PRETTY_FUNCTION__ << " " << mName << ": processing tracks momentum = " << momentum
-              << " eta = " << eta
-              << " Nsigma_piK = " << Nsigma_piK << " Nsigma_Kp = " << Nsigma_Kp
-              << std::endl;
+    std::cout << __PRETTY_FUNCTION__ << " " << mName
+              << ": processing tracks momentum = " << momentum
+              << " eta = " << eta << " Nsigma_piK = " << Nsigma_piK
+              << " Nsigma_Kp = " << Nsigma_Kp << std::endl;
 
   const double pion_sigma_space_ring_radius = +Nsigma_piK;
   const double kaon_sigma_space_ring_radius = 0;
@@ -73,18 +69,18 @@ ECCEdRICHFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double momen
   else if (abs_truth_pid == EICPIDDefs::ProtonCandiate)
     sigma_space_ring_radius += proton_sigma_space_ring_radius;
 
-  ll_map[EICPIDDefs::PionCandiate] = -0.5 * pow(sigma_space_ring_radius - pion_sigma_space_ring_radius, 2);
-  ll_map[EICPIDDefs::KaonCandiate] = -0.5 * pow(sigma_space_ring_radius - kaon_sigma_space_ring_radius, 2);
-  ll_map[EICPIDDefs::ProtonCandiate] = -0.5 * pow(sigma_space_ring_radius - proton_sigma_space_ring_radius, 2);
+  ll_map[EICPIDDefs::PionCandiate] =
+      -0.5 * pow(sigma_space_ring_radius - pion_sigma_space_ring_radius, 2);
+  ll_map[EICPIDDefs::KaonCandiate] =
+      -0.5 * pow(sigma_space_ring_radius - kaon_sigma_space_ring_radius, 2);
+  ll_map[EICPIDDefs::ProtonCandiate] =
+      -0.5 * pow(sigma_space_ring_radius - proton_sigma_space_ring_radius, 2);
 
   return ll_map;
 }
 
-double
-ECCEdRICHFastPIDMap::etaMin() const
-{
-  switch (mType)
-  {
+double ECCEdRICHFastPIDMap::etaMin() const {
+  switch (mType) {
   case kBarrel:
     return -log(tan(atan2(mRadius, -mLength) * 0.5));
   case kForward:
@@ -93,11 +89,8 @@ ECCEdRICHFastPIDMap::etaMin() const
   return 0.;
 }
 
-double
-ECCEdRICHFastPIDMap::etaMax() const
-{
-  switch (mType)
-  {
+double ECCEdRICHFastPIDMap::etaMax() const {
+  switch (mType) {
   case kBarrel:
     return -log(tan(atan2(mRadius, mLength) * 0.5));
   case kForward:
@@ -106,27 +99,31 @@ ECCEdRICHFastPIDMap::etaMax() const
   return 0.;
 }
 
-void ECCEdRICHFastPIDMap::dualRICH_aerogel()
-{
+void ECCEdRICHFastPIDMap::dualRICH_aerogel() {
   initialized = true;
   setName("aerogel");
   /** geometry **/
   setType(kForward);
-  setRadiusIn(10.);    // [cm]
-  setRadiusOut(120.);  // [cm]
-  setPositionZ(250.);  // [cm]
+  setRadiusIn(10.);   // [cm]
+  setRadiusOut(120.); // [cm]
+  setPositionZ(250.); // [cm]
   /** radiator **/
-  setLength(4.);  // [cm]
+  setLength(4.); // [cm]
   setIndex(1.02);
   /** overall photon-detection efficiency **/
   setEfficiency(0.08);
   /** single-photon angular resolution **/
-  double angle[5] = {5., 10., 15., 20., 25.};                                              // [deg]
-  double chromatic[5] = {0.00260572, 0.00223447, 0.00229996, 0.00237615, 0.00245689};      // [rad] from actual file
-  double emission[5] = {0.000658453, 0.000297004, 0.00014763, 0.000196477, 0.000596087};   // [rad] from actual file
-  double pixel[5] = {0.000502646, 0.000575427, 0.000551095, 0.000555055, 0.000564831};     // [rad] from actual file
-  double field[5] = {8.13634e-05, 6.41901e-05, 3.92289e-05, 9.76800e-05, 2.58328e-05};     // [rad] from actual file
-  double tracking[5] = {0.000350351, 0.000306691, 0.000376006, 0.000401814, 0.000389742};  // [rad] from actual file
+  double angle[5] = {5., 10., 15., 20., 25.}; // [deg]
+  double chromatic[5] = {0.00260572, 0.00223447, 0.00229996, 0.00237615,
+                         0.00245689}; // [rad] from actual file
+  double emission[5] = {0.000658453, 0.000297004, 0.00014763, 0.000196477,
+                        0.000596087}; // [rad] from actual file
+  double pixel[5] = {0.000502646, 0.000575427, 0.000551095, 0.000555055,
+                     0.000564831}; // [rad] from actual file
+  double field[5] = {8.13634e-05, 6.41901e-05, 3.92289e-05, 9.76800e-05,
+                     2.58328e-05}; // [rad] from actual file
+  double tracking[5] = {0.000350351, 0.000306691, 0.000376006, 0.000401814,
+                        0.000389742}; // [rad] from actual file
   setChromaticSigma(5, angle, chromatic);
   setPositionSigma(5, angle, pixel);
   setEmissionSigma(5, angle, emission);
@@ -134,27 +131,31 @@ void ECCEdRICHFastPIDMap::dualRICH_aerogel()
   setTrackingSigma(5, angle, tracking);
 }
 
-void ECCEdRICHFastPIDMap::dualRICH_C2F6()
-{
+void ECCEdRICHFastPIDMap::dualRICH_C2F6() {
   initialized = true;
   setName("C2F6");
   /** geometry **/
   setType(kForward);
-  setRadiusIn(10.);    // [cm]
-  setRadiusOut(120.);  // [cm]
-  setPositionZ(250.);  // [cm]
+  setRadiusIn(10.);   // [cm]
+  setRadiusOut(120.); // [cm]
+  setPositionZ(250.); // [cm]
   /** radiator **/
-  setLength(160.);  // [cm]
+  setLength(160.); // [cm]
   setIndex(1.0008);
   /** overall photon-detection efficiency **/
   setEfficiency(0.15);
   /** single-photon angular resolution **/
-  double angle[5] = {5., 10., 15., 20., 25.};                                               // [deg]
-  double chromatic[5] = {0.000516327, 0.000527914, 0.000525467, 0.000515349, 0.000489377};  // [rad] from actual file
-  double emission[5] = {0.001439090, 0.000718037, 0.000656786, 0.000946782, 0.001404630};   // [rad] from actual file
-  double pixel[5] = {0.000480520, 0.000533282, 0.000564187, 0.000577872, 0.000605236};      // [rad] from actual file
-  double field[5] = {8.60521e-05, 7.64798e-05, 0.000167358, 0.000475598, 0.000629863};      // [rad] from actual file
-  double tracking[5] = {0.000389136, 0.000328530, 0.000402517, 0.000417901, 0.000393391};   // [rad] from actual file
+  double angle[5] = {5., 10., 15., 20., 25.}; // [deg]
+  double chromatic[5] = {0.000516327, 0.000527914, 0.000525467, 0.000515349,
+                         0.000489377}; // [rad] from actual file
+  double emission[5] = {0.001439090, 0.000718037, 0.000656786, 0.000946782,
+                        0.001404630}; // [rad] from actual file
+  double pixel[5] = {0.000480520, 0.000533282, 0.000564187, 0.000577872,
+                     0.000605236}; // [rad] from actual file
+  double field[5] = {8.60521e-05, 7.64798e-05, 0.000167358, 0.000475598,
+                     0.000629863}; // [rad] from actual file
+  double tracking[5] = {0.000389136, 0.000328530, 0.000402517, 0.000417901,
+                        0.000393391}; // [rad] from actual file
   setChromaticSigma(5, angle, chromatic);
   setPositionSigma(5, angle, pixel);
   setEmissionSigma(5, angle, emission);
@@ -162,8 +163,8 @@ void ECCEdRICHFastPIDMap::dualRICH_C2F6()
   setTrackingSigma(5, angle, tracking);
 }
 
-double ECCEdRICHFastPIDMap::cherenkovAngleSigma(double eta, double p, double m) const
-{
+double ECCEdRICHFastPIDMap::cherenkovAngleSigma(double eta, double p,
+                                                double m) const {
   auto theta = 2. * atan(exp(-eta)) * 57.295780;
   auto chromatic = mChromaticSigma ? mChromaticSigma->Eval(theta) : 0.;
   auto position = mPositionSigma ? mPositionSigma->Eval(theta) : 0.;
@@ -173,22 +174,18 @@ double ECCEdRICHFastPIDMap::cherenkovAngleSigma(double eta, double p, double m) 
 
   // contributions that scale with number of detected photons
   auto ndet = numberOfDetectedPhotons(cherenkovAngle(p, m));
-  auto sigma1 = sqrt(chromatic * chromatic +
-                     position * position +
-                     emission * emission +
-                     field * field +
-                     tracking * tracking);
+  auto sigma1 = sqrt(chromatic * chromatic + position * position +
+                     emission * emission + field * field + tracking * tracking);
   // contributions that do not
   auto sigma2 = 0.;
   //
   return sqrt(sigma1 * sigma1 / ndet + sigma2 * sigma2);
 };
 
-double ECCEdRICHFastPIDMap::numSigma(double eta, double p, ECCEdRICHFastPIDMap::type PID) const
-{
+double ECCEdRICHFastPIDMap::numSigma(double eta, double p,
+                                     ECCEdRICHFastPIDMap::type PID) const {
   double mass1(0), mass2(0);
-  switch (PID)
-  {
+  switch (PID) {
   case pi_k:
     mass1 = mMassPion;
     mass2 = mMassKaon;
@@ -198,7 +195,7 @@ double ECCEdRICHFastPIDMap::numSigma(double eta, double p, ECCEdRICHFastPIDMap::
     mass2 = mMassProton;
     break;
   default:
-    assert(0);  // exit the code for logical error
+    assert(0); // exit the code for logical error
     exit(1);
   }
 
@@ -206,29 +203,29 @@ double ECCEdRICHFastPIDMap::numSigma(double eta, double p, ECCEdRICHFastPIDMap::
   double thr2 = cherenkovThreshold(mass2);
 
   if (Verbosity())
-    std::cout << __PRETTY_FUNCTION__ << " " << mName << ": processing tracks momentum = " << p
-              << " eta = " << eta
-              << " thr1 = " << thr1 << " thr2 = " << thr2
-              << std::endl;
+    std::cout << __PRETTY_FUNCTION__ << " " << mName
+              << ": processing tracks momentum = " << p << " eta = " << eta
+              << " thr1 = " << thr1 << " thr2 = " << thr2 << std::endl;
 
   /** both particles are above threshold **/
-  if (p > thr1 && p > thr2)
-  {
+  if (p > thr1 && p > thr2) {
 
     if (Verbosity())
-      std::cout << __PRETTY_FUNCTION__ << " " << mName << ": processing tracks momentum = " << p
-                << " eta = " << eta
+      std::cout << __PRETTY_FUNCTION__ << " " << mName
+                << ": processing tracks momentum = " << p << " eta = " << eta
                 << " cherenkovAngle(p, mass1) = " << cherenkovAngle(p, mass1)
-                << "  cherenkovAngle(p, mass2)) = " <<  cherenkovAngle(p, mass2)
-                << "  cherenkovAngleSigma(eta, p, mass1) = " <<  cherenkovAngleSigma(eta, p, mass1)
-                << std::endl;
+                << "  cherenkovAngle(p, mass2)) = " << cherenkovAngle(p, mass2)
+                << "  cherenkovAngleSigma(eta, p, mass1) = "
+                << cherenkovAngleSigma(eta, p, mass1) << std::endl;
 
-
-    return (cherenkovAngle(p, mass1) - cherenkovAngle(p, mass2)) / cherenkovAngleSigma(eta, p, mass1);
+    return (cherenkovAngle(p, mass1) - cherenkovAngle(p, mass2)) /
+           cherenkovAngleSigma(eta, p, mass1);
   }
   /** lightest particle above threshold **/
   if (mThresholdMode && p > thr1)
-    return (cherenkovAngle(thr2 + 0.001, mass1) - cherenkovAngle(thr2 + 0.001, mass2)) / cherenkovAngleSigma(eta, thr2 + 0.001, mass1);
+    return (cherenkovAngle(thr2 + 0.001, mass1) -
+            cherenkovAngle(thr2 + 0.001, mass2)) /
+           cherenkovAngleSigma(eta, thr2 + 0.001, mass1);
 
   /** none above threshold **/
   return 0.;

--- a/FastPID/ECCEdRICHFastPIDMap.h
+++ b/FastPID/ECCEdRICHFastPIDMap.h
@@ -15,12 +15,15 @@
 
 #include <string>
 
+#include <cmath>
+
 class TH2F;
 class TF1;
 
+#include <TGraph.h>
 /*!
  * \brief ECCEdRICHFastPIDMap
- * Import from DrcPidFast
+ * Import from dRICH/genericRICH
  */
 class ECCEdRICHFastPIDMap : public ECCEFastPIDMap
 {
@@ -28,33 +31,109 @@ class ECCEdRICHFastPIDMap : public ECCEFastPIDMap
   ECCEdRICHFastPIDMap();
   virtual ~ECCEdRICHFastPIDMap();
 
+  //! set one of these two first
+  void dualRICH_aerogel();
+  void dualRICH_C2F6();
+
   PIDCandidate_LogLikelihood_map getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta) const override;
 
-  //! read Cherenkov track resolution map from a file
-  void ReadMap(const std::string &name);
-
-  TH2F *GetTrrMap() { return fTrrMap; }
-
- private:
-  //! probability - normalized to 1 probability for e,mu,pi,k,p
-  //! sigma - deviation of the determined Cherenkov angle from expected in terms of Cherenkov track
-  //! resolution cangle - Cherenkov angle cctr -  combined Cherenkov track resolution
-  struct DrcPidInfo
+  enum type
   {
-    double probability[5] = {0};
-    double sigma[5] = {0};
-    double cangle = 0;
-    double cctr = 0;
+    pi_k,
+    k_p
   };
 
-  static int get_pid(int pdg) ;
-  static EICPIDDefs::PIDCandidate get_PIDCandidate(int id) ;
+  enum EDetector_t
+  {
+    kBarrel,
+    kForward
+  };
 
-  TH2F *fTrrMap = nullptr;
-  double fMass[5] = {0};
-  TF1 *fMs_mom = nullptr;
-  TF1 *fMs_thickness = nullptr;
-  double fMs_thickness_max = (0);
+  /** setters **/
+  void setIndex(double val) { mIndex = val; };
+  void setEfficiency(double val) { mEfficiency = val; };
+  void setMinPhotons(double val) { mMinPhotons = val; };
+  void setThresholdMode(bool val) { mThresholdMode = val; };
+
+  void setChromaticSigma(int n, double *valx, double *valy)
+  {
+    if (mChromaticSigma) delete mChromaticSigma;
+    mChromaticSigma = new TGraph(n, valx, valy);
+  }
+  void setPositionSigma(int n, double *valx, double *valy)
+  {
+    if (mPositionSigma) delete mPositionSigma;
+    mPositionSigma = new TGraph(n, valx, valy);
+  }
+  void setEmissionSigma(int n, double *valx, double *valy)
+  {
+    if (mEmissionSigma) delete mEmissionSigma;
+    mEmissionSigma = new TGraph(n, valx, valy);
+  }
+  void setFieldSigma(int n, double *valx, double *valy)
+  {
+    if (mFieldSigma) delete mFieldSigma;
+    mFieldSigma = new TGraph(n, valx, valy);
+  }
+  void setTrackingSigma(int n, double *valx, double *valy)
+  {
+    if (mTrackingSigma) delete mTrackingSigma;
+    mTrackingSigma = new TGraph(n, valx, valy);
+  }
+
+  /** methods to override **/
+  double numSigma(double eta, double p, type PID) const;
+
+  double cherenkovAngle(double p, double m) const { return acos(sqrt(m * m + p * p) / (mIndex * p)); };
+  double cherenkovThreshold(double m) const { return m / sqrt(mIndex * mIndex - 1.); };
+  double numberOfPhotons(double angle) const { return 490. * sin(angle) * sin(angle) * mLength; };
+  double numberOfDetectedPhotons(double angle) const { return numberOfPhotons(angle) * mEfficiency; };
+  double cherenkovAngleSigma(double eta, double p, double m) const;
+
+  double etaMin() const;
+  double etaMax() const;
+  /** setters **/
+  void setType(EDetector_t val) { mType = val; };
+  void setName(const std::string &val) { mName = val; };
+  void setLength(double val) { mLength = val; };
+  void setRadius(double val) { mRadius = val; };
+  void setPositionZ(double val) { mPositionZ = val; };
+  void setRadiusIn(double val) { mRadiusIn = val; };
+  void setRadiusOut(double val) { mRadiusOut = val; };
+  void setMagneticField(double val) { mMagneticField = val; };
+
+ protected:
+  // RICH parameters
+  double mIndex = 1.0014;     // refractive index
+  double mEfficiency = 0.25;  // overall photon detection efficiency
+  double mMinPhotons = 3.;    // minimum number of detected photons
+
+  // contributions to resolution
+  TGraph *mChromaticSigma = nullptr;  // chromatic resolution vs. polar angle [rad]
+  TGraph *mPositionSigma = nullptr;   // position resolution vs. polar angle [rad]
+  TGraph *mEmissionSigma = nullptr;   // emission resolution vs. polar angle [rad]
+  TGraph *mFieldSigma = nullptr;      // field resolution vs. polar angle [rad]
+  TGraph *mTrackingSigma = nullptr;   // tracking resolution vs. polar angle [rad]
+
+  // threshold mode
+  bool mThresholdMode = true;
+
+  bool initialized = false;
+  std::string mName = "genericDetector";
+  std::string mDescription = "Detector description";
+  EDetector_t mType = kBarrel;
+  double mLength = 200.;       // [cm]
+  double mRadius = 200.;       // [cm]
+  double mPositionZ = 200.;    // [cm]
+  double mRadiusIn = 20.;      // [cm]
+  double mRadiusOut = 200.;    // [cm]
+  double mMagneticField = 2.;  // [T]
+
+  const double mLightSpeed = 29.9792458;       // speed of light [cm/ns]
+  const double mMassElectron = 0.00051099891;  // electron mass [GeV]
+  const double mMassPion = 0.13957018;         // pion mass [GeV]
+  const double mMassKaon = 0.493677;           // kaon mass [GeV]
+  const double mMassProton = 0.93827208816;    // proton mass [GeV]
 };
 
 #endif /* ECCEdRICHFastPIDMap_H_ */

--- a/FastPID/ECCEdRICHFastPIDMap.h
+++ b/FastPID/ECCEdRICHFastPIDMap.h
@@ -2,7 +2,7 @@
 
 /*!
  * \file ECCEdRICHFastPIDMap.h
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $
@@ -25,9 +25,8 @@ class TF1;
  * \brief ECCEdRICHFastPIDMap
  * Import from dRICH/genericRICH
  */
-class ECCEdRICHFastPIDMap : public ECCEFastPIDMap
-{
- public:
+class ECCEdRICHFastPIDMap : public ECCEFastPIDMap {
+public:
   ECCEdRICHFastPIDMap();
   virtual ~ECCEdRICHFastPIDMap();
 
@@ -35,19 +34,13 @@ class ECCEdRICHFastPIDMap : public ECCEFastPIDMap
   void dualRICH_aerogel();
   void dualRICH_C2F6();
 
-  PIDCandidate_LogLikelihood_map getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta) const override;
+  PIDCandidate_LogLikelihood_map
+  getFastSmearLogLikelihood(int truth_pid, const double momentum,
+                            const double theta) const override;
 
-  enum type
-  {
-    pi_k,
-    k_p
-  };
+  enum type { pi_k, k_p };
 
-  enum EDetector_t
-  {
-    kBarrel,
-    kForward
-  };
+  enum EDetector_t { kBarrel, kForward };
 
   /** setters **/
   void setIndex(double val) { mIndex = val; };
@@ -55,39 +48,47 @@ class ECCEdRICHFastPIDMap : public ECCEFastPIDMap
   void setMinPhotons(double val) { mMinPhotons = val; };
   void setThresholdMode(bool val) { mThresholdMode = val; };
 
-  void setChromaticSigma(int n, double *valx, double *valy)
-  {
-    if (mChromaticSigma) delete mChromaticSigma;
+  void setChromaticSigma(int n, double *valx, double *valy) {
+    if (mChromaticSigma)
+      delete mChromaticSigma;
     mChromaticSigma = new TGraph(n, valx, valy);
   }
-  void setPositionSigma(int n, double *valx, double *valy)
-  {
-    if (mPositionSigma) delete mPositionSigma;
+  void setPositionSigma(int n, double *valx, double *valy) {
+    if (mPositionSigma)
+      delete mPositionSigma;
     mPositionSigma = new TGraph(n, valx, valy);
   }
-  void setEmissionSigma(int n, double *valx, double *valy)
-  {
-    if (mEmissionSigma) delete mEmissionSigma;
+  void setEmissionSigma(int n, double *valx, double *valy) {
+    if (mEmissionSigma)
+      delete mEmissionSigma;
     mEmissionSigma = new TGraph(n, valx, valy);
   }
-  void setFieldSigma(int n, double *valx, double *valy)
-  {
-    if (mFieldSigma) delete mFieldSigma;
+  void setFieldSigma(int n, double *valx, double *valy) {
+    if (mFieldSigma)
+      delete mFieldSigma;
     mFieldSigma = new TGraph(n, valx, valy);
   }
-  void setTrackingSigma(int n, double *valx, double *valy)
-  {
-    if (mTrackingSigma) delete mTrackingSigma;
+  void setTrackingSigma(int n, double *valx, double *valy) {
+    if (mTrackingSigma)
+      delete mTrackingSigma;
     mTrackingSigma = new TGraph(n, valx, valy);
   }
 
   /** methods to override **/
   double numSigma(double eta, double p, type PID) const;
 
-  double cherenkovAngle(double p, double m) const { return acos(sqrt(m * m + p * p) / (mIndex * p)); };
-  double cherenkovThreshold(double m) const { return m / sqrt(mIndex * mIndex - 1.); };
-  double numberOfPhotons(double angle) const { return 490. * sin(angle) * sin(angle) * mLength; };
-  double numberOfDetectedPhotons(double angle) const { return numberOfPhotons(angle) * mEfficiency; };
+  double cherenkovAngle(double p, double m) const {
+    return acos(sqrt(m * m + p * p) / (mIndex * p));
+  };
+  double cherenkovThreshold(double m) const {
+    return m / sqrt(mIndex * mIndex - 1.);
+  };
+  double numberOfPhotons(double angle) const {
+    return 490. * sin(angle) * sin(angle) * mLength;
+  };
+  double numberOfDetectedPhotons(double angle) const {
+    return numberOfPhotons(angle) * mEfficiency;
+  };
   double cherenkovAngleSigma(double eta, double p, double m) const;
 
   double etaMin() const;
@@ -102,18 +103,19 @@ class ECCEdRICHFastPIDMap : public ECCEFastPIDMap
   void setRadiusOut(double val) { mRadiusOut = val; };
   void setMagneticField(double val) { mMagneticField = val; };
 
- protected:
+protected:
   // RICH parameters
-  double mIndex = 1.0014;     // refractive index
-  double mEfficiency = 0.25;  // overall photon detection efficiency
-  double mMinPhotons = 3.;    // minimum number of detected photons
+  double mIndex = 1.0014;    // refractive index
+  double mEfficiency = 0.25; // overall photon detection efficiency
+  double mMinPhotons = 3.;   // minimum number of detected photons
 
   // contributions to resolution
-  TGraph *mChromaticSigma = nullptr;  // chromatic resolution vs. polar angle [rad]
-  TGraph *mPositionSigma = nullptr;   // position resolution vs. polar angle [rad]
-  TGraph *mEmissionSigma = nullptr;   // emission resolution vs. polar angle [rad]
-  TGraph *mFieldSigma = nullptr;      // field resolution vs. polar angle [rad]
-  TGraph *mTrackingSigma = nullptr;   // tracking resolution vs. polar angle [rad]
+  TGraph *mChromaticSigma =
+      nullptr; // chromatic resolution vs. polar angle [rad]
+  TGraph *mPositionSigma = nullptr; // position resolution vs. polar angle [rad]
+  TGraph *mEmissionSigma = nullptr; // emission resolution vs. polar angle [rad]
+  TGraph *mFieldSigma = nullptr;    // field resolution vs. polar angle [rad]
+  TGraph *mTrackingSigma = nullptr; // tracking resolution vs. polar angle [rad]
 
   // threshold mode
   bool mThresholdMode = true;
@@ -122,18 +124,18 @@ class ECCEdRICHFastPIDMap : public ECCEFastPIDMap
   std::string mName = "genericDetector";
   std::string mDescription = "Detector description";
   EDetector_t mType = kBarrel;
-  double mLength = 200.;       // [cm]
-  double mRadius = 200.;       // [cm]
-  double mPositionZ = 200.;    // [cm]
-  double mRadiusIn = 20.;      // [cm]
-  double mRadiusOut = 200.;    // [cm]
-  double mMagneticField = 2.;  // [T]
+  double mLength = 200.;      // [cm]
+  double mRadius = 200.;      // [cm]
+  double mPositionZ = 200.;   // [cm]
+  double mRadiusIn = 20.;     // [cm]
+  double mRadiusOut = 200.;   // [cm]
+  double mMagneticField = 2.; // [T]
 
-  const double mLightSpeed = 29.9792458;       // speed of light [cm/ns]
-  const double mMassElectron = 0.00051099891;  // electron mass [GeV]
-  const double mMassPion = 0.13957018;         // pion mass [GeV]
-  const double mMassKaon = 0.493677;           // kaon mass [GeV]
-  const double mMassProton = 0.93827208816;    // proton mass [GeV]
+  const double mLightSpeed = 29.9792458;      // speed of light [cm/ns]
+  const double mMassElectron = 0.00051099891; // electron mass [GeV]
+  const double mMassPion = 0.13957018;        // pion mass [GeV]
+  const double mMassKaon = 0.493677;          // kaon mass [GeV]
+  const double mMassProton = 0.93827208816;   // proton mass [GeV]
 };
 
 #endif /* ECCEdRICHFastPIDMap_H_ */

--- a/FastPID/ECCEdRICHFastPIDMap.h
+++ b/FastPID/ECCEdRICHFastPIDMap.h
@@ -1,0 +1,60 @@
+// $Id: $
+
+/*!
+ * \file ECCEdRICHFastPIDMap.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef ECCEdRICHFastPIDMap_H_
+#define ECCEdRICHFastPIDMap_H_
+
+#include "ECCEFastPIDMap.h"
+
+#include <string>
+
+class TH2F;
+class TF1;
+
+/*!
+ * \brief ECCEdRICHFastPIDMap
+ * Import from DrcPidFast
+ */
+class ECCEdRICHFastPIDMap : public ECCEFastPIDMap
+{
+ public:
+  ECCEdRICHFastPIDMap();
+  virtual ~ECCEdRICHFastPIDMap();
+
+  PIDCandidate_LogLikelihood_map getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta) const override;
+
+  //! read Cherenkov track resolution map from a file
+  void ReadMap(const std::string &name);
+
+  TH2F *GetTrrMap() { return fTrrMap; }
+
+ private:
+  //! probability - normalized to 1 probability for e,mu,pi,k,p
+  //! sigma - deviation of the determined Cherenkov angle from expected in terms of Cherenkov track
+  //! resolution cangle - Cherenkov angle cctr -  combined Cherenkov track resolution
+  struct DrcPidInfo
+  {
+    double probability[5] = {0};
+    double sigma[5] = {0};
+    double cangle = 0;
+    double cctr = 0;
+  };
+
+  static int get_pid(int pdg) ;
+  static EICPIDDefs::PIDCandidate get_PIDCandidate(int id) ;
+
+  TH2F *fTrrMap = nullptr;
+  double fMass[5] = {0};
+  TF1 *fMs_mom = nullptr;
+  TF1 *fMs_thickness = nullptr;
+  double fMs_thickness_max = (0);
+};
+
+#endif /* ECCEdRICHFastPIDMap_H_ */

--- a/FastPID/ECCEhpDIRCFastPIDMap.cc
+++ b/FastPID/ECCEhpDIRCFastPIDMap.cc
@@ -2,7 +2,7 @@
 
 /*!
  * \file ECCEhpDIRCFastPIDMap.cc
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $
@@ -20,8 +20,7 @@
 #include <cassert>
 #include <cmath>
 
-ECCEhpDIRCFastPIDMap::ECCEhpDIRCFastPIDMap()
-{
+ECCEhpDIRCFastPIDMap::ECCEhpDIRCFastPIDMap() {
   int barid = 0;
 
   fMass[0] = 0.000511;
@@ -32,30 +31,30 @@ ECCEhpDIRCFastPIDMap::ECCEhpDIRCFastPIDMap()
 
   // multiple scattering for 17 mm thick radiator at 30 deg
   fMs_mom = new TF1("", "expo(0)+expo(2)+expo(4)");
-  fMs_mom->SetParameters(4.40541e+00, -5.52436e+00, 2.35058e+00, -1.02703e+00, 9.55032e-01,
-                         -1.48500e-01);
-  // fMs_mom->SetParameters(9.39815e-01, -1.48243e-01, 4.69733e+00, -4.33960e+00, 2.19745e+00,
+  fMs_mom->SetParameters(4.40541e+00, -5.52436e+00, 2.35058e+00, -1.02703e+00,
+                         9.55032e-01, -1.48500e-01);
+  // fMs_mom->SetParameters(9.39815e-01, -1.48243e-01, 4.69733e+00,
+  // -4.33960e+00, 2.19745e+00,
   //                       -9.68617e-01);
 
   fMs_thickness = new TF1("", "pol1");
 
   if (barid == 1)
-    fMs_thickness->SetParameters(3.5, 0.0214286);  // 10 mm bar
+    fMs_thickness->SetParameters(3.5, 0.0214286); // 10 mm bar
   else
-    fMs_thickness->SetParameters(4.5, 0.0357143);  // 17 mm bar
+    fMs_thickness->SetParameters(4.5, 0.0357143); // 17 mm bar
 
   TF1 *fMs_thickness_17 = new TF1("", "pol1");
-  fMs_thickness_17->SetParameters(4.5, 0.0357143);  // 17 mm bar
+  fMs_thickness_17->SetParameters(4.5, 0.0357143); // 17 mm bar
   fMs_thickness_max = fMs_thickness_17->Eval(70);
 }
 
-ECCEhpDIRCFastPIDMap::~ECCEhpDIRCFastPIDMap()
-{
-}
+ECCEhpDIRCFastPIDMap::~ECCEhpDIRCFastPIDMap() {}
 
 ECCEhpDIRCFastPIDMap::PIDCandidate_LogLikelihood_map
-ECCEhpDIRCFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta_rad) const
-{
+ECCEhpDIRCFastPIDMap::getFastSmearLogLikelihood(int truth_pid,
+                                                const double momentum,
+                                                const double theta_rad) const {
   assert(fTrrMap);
 
   // preprocessing
@@ -77,14 +76,12 @@ ECCEhpDIRCFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double mome
   DrcPidInfo info;
   int pid = get_pid(truth_pid);
 
-  if (pid == 0)
-  {
+  if (pid == 0) {
     return ll_map;
   }
 
   // set default values
-  for (int i = 0; i < max; i++)
-  {
+  for (int i = 0; i < max; i++) {
     info.probability[i] = 0.25;
     info.sigma[i] = 100;
   }
@@ -96,7 +93,7 @@ ECCEhpDIRCFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double mome
   //    std::cout<<"theta out of [20,160] deg range: "<<theta<<std::endl;
   //  }
 
-  double ms_mom_err = fMs_mom->Eval(p);  // vector deviation after radiator
+  double ms_mom_err = fMs_mom->Eval(p); // vector deviation after radiator
 
   double alpha = (theta < 90) ? 90 - theta : theta - 90;
   double ms_thick_frac = fMs_thickness->Eval(alpha) / fMs_thickness_max;
@@ -105,54 +102,60 @@ ECCEhpDIRCFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double mome
   double ms_err = 0.31 * ms_mom_err * ms_thick_frac;
 
   // ctr map is for theta = [25,153] and p = [0,10] GeV/c
-  if (theta < 25) theta = 25;
-  if (theta > 153) theta = 153;
-  if (p > 10) p = 10;
+  if (theta < 25)
+    theta = 25;
+  if (theta > 153)
+    theta = 153;
+  if (p > 10)
+    p = 10;
 
   int bin = fTrrMap->FindBin(theta, p);
-  double ctr = fTrrMap->GetBinContent(bin);  // Cherenkov track resolution [mrad]
+  double ctr = fTrrMap->GetBinContent(bin); // Cherenkov track resolution [mrad]
   double cctr = sqrt(ctr * ctr + track_err * track_err + ms_err * ms_err) *
-                0.001;  // combined Cherenkov track resolution[rad]
+                0.001; // combined Cherenkov track resolution[rad]
 
   // 1.46907 - fused silica
-  double true_cangle = acos(sqrt(p * p + fMass[pid] * fMass[pid]) / p / 1.46907);
+  double true_cangle =
+      acos(sqrt(p * p + fMass[pid] * fMass[pid]) / p / 1.46907);
   true_cangle += gRandom->Gaus(0, cctr);
 
-  // return default values if momentum below Cherenkov threshold (true_cangle is NaN)
-  if (isnan(true_cangle)) return ll_map;
+  // return default values if momentum below Cherenkov threshold (true_cangle is
+  // NaN)
+  if (isnan(true_cangle))
+    return ll_map;
 
   double cangle, sum = 0, fsum = 0;
-  double delta[max] = {0};  //, probability[max] = {0};
+  double delta[max] = {0}; //, probability[max] = {0};
 
-  for (int i = 0; i < max; i++)
-  {
+  for (int i = 0; i < max; i++) {
     cangle = acos(sqrt(p * p + fMass[i] * fMass[i]) / p / 1.46907);
-    if (isnan(cangle))
-    {
-      ll_map[get_PIDCandidate(i)] = -100;  // set non-firing particle candidate to low probability
+    if (isnan(cangle)) {
+      ll_map[get_PIDCandidate(i)] =
+          -100; // set non-firing particle candidate to low probability
       continue;
     }
     delta[i] = fabs(cangle - true_cangle);
     sum += delta[i];
     info.sigma[i] = (cangle - true_cangle) / cctr;
-    if (i == pid) info.cangle = cangle;
+    if (i == pid)
+      info.cangle = cangle;
 
     ll_map[get_PIDCandidate(i)] = -0.5 * info.sigma[i] * info.sigma[i];
   }
   // normalization
-  for (int i = 0; i < max; i++)
-  {
-    if (delta[i] > 0) info.probability[i] = sum / delta[i];
+  for (int i = 0; i < max; i++) {
+    if (delta[i] > 0)
+      info.probability[i] = sum / delta[i];
     fsum += info.probability[i];
   }
-  for (int i = 0; i < max; i++) info.probability[i] /= fsum;
+  for (int i = 0; i < max; i++)
+    info.probability[i] /= fsum;
   info.cctr = cctr;
 
   return ll_map;
 }
 
-void ECCEhpDIRCFastPIDMap::ReadMap(const std::string &name)
-{
+void ECCEhpDIRCFastPIDMap::ReadMap(const std::string &name) {
   TFile *file = TFile::Open(name.c_str());
   assert(file);
   //  fTrrMap = new TH2F();
@@ -160,25 +163,33 @@ void ECCEhpDIRCFastPIDMap::ReadMap(const std::string &name)
   assert(fTrrMap);
 }
 
-int ECCEhpDIRCFastPIDMap::get_pid(int pdg)
-{
+int ECCEhpDIRCFastPIDMap::get_pid(int pdg) {
   int pid = 0;
-  if (pdg == 11) pid = 0;    // e
-  if (pdg == 13) pid = 1;    // mu
-  if (pdg == 211) pid = 2;   // pi
-  if (pdg == 321) pid = 3;   // K
-  if (pdg == 2212) pid = 4;  // p
+  if (pdg == 11)
+    pid = 0; // e
+  if (pdg == 13)
+    pid = 1; // mu
+  if (pdg == 211)
+    pid = 2; // pi
+  if (pdg == 321)
+    pid = 3; // K
+  if (pdg == 2212)
+    pid = 4; // p
   return pid;
 }
 
-EICPIDDefs::PIDCandidate ECCEhpDIRCFastPIDMap::get_PIDCandidate(int pid)
-{
+EICPIDDefs::PIDCandidate ECCEhpDIRCFastPIDMap::get_PIDCandidate(int pid) {
   EICPIDDefs::PIDCandidate id = EICPIDDefs::InvalidCandiate;
-  if (pid == 0) id = EICPIDDefs::ElectronCandiate;  // e
-  if (pid == 1) id = EICPIDDefs::MuonCandiate;      // mu
-  if (pid == 2) id = EICPIDDefs::PionCandiate;      // pi
-  if (pid == 3) id = EICPIDDefs::KaonCandiate;      // K
-  if (pid == 4) id = EICPIDDefs::ProtonCandiate;    // p
+  if (pid == 0)
+    id = EICPIDDefs::ElectronCandiate; // e
+  if (pid == 1)
+    id = EICPIDDefs::MuonCandiate; // mu
+  if (pid == 2)
+    id = EICPIDDefs::PionCandiate; // pi
+  if (pid == 3)
+    id = EICPIDDefs::KaonCandiate; // K
+  if (pid == 4)
+    id = EICPIDDefs::ProtonCandiate; // p
   assert(id != EICPIDDefs::InvalidCandiate);
 
   return id;

--- a/FastPID/ECCEhpDIRCFastPIDMap.cc
+++ b/FastPID/ECCEhpDIRCFastPIDMap.cc
@@ -1,0 +1,185 @@
+// $Id: $
+
+/*!
+ * \file ECCEhpDIRCFastPIDMap.cc
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "ECCEhpDIRCFastPIDMap.h"
+
+#include <TF1.h>
+#include <TFile.h>
+#include <TH2F.h>
+#include <TMath.h>
+#include <TRandom.h>
+#include <TVector3.h>
+
+#include <cassert>
+#include <cmath>
+
+ECCEhpDIRCFastPIDMap::ECCEhpDIRCFastPIDMap()
+{
+  int barid = 0;
+
+  fMass[0] = 0.000511;
+  fMass[1] = 0.105658;
+  fMass[2] = 0.139570;
+  fMass[3] = 0.49368;
+  fMass[4] = 0.938272;
+
+  // multiple scattering for 17 mm thick radiator at 30 deg
+  fMs_mom = new TF1("", "expo(0)+expo(2)+expo(4)");
+  fMs_mom->SetParameters(4.40541e+00, -5.52436e+00, 2.35058e+00, -1.02703e+00, 9.55032e-01,
+                         -1.48500e-01);
+  // fMs_mom->SetParameters(9.39815e-01, -1.48243e-01, 4.69733e+00, -4.33960e+00, 2.19745e+00,
+  //                       -9.68617e-01);
+
+  fMs_thickness = new TF1("", "pol1");
+
+  if (barid == 1)
+    fMs_thickness->SetParameters(3.5, 0.0214286);  // 10 mm bar
+  else
+    fMs_thickness->SetParameters(4.5, 0.0357143);  // 17 mm bar
+
+  TF1 *fMs_thickness_17 = new TF1("", "pol1");
+  fMs_thickness_17->SetParameters(4.5, 0.0357143);  // 17 mm bar
+  fMs_thickness_max = fMs_thickness_17->Eval(70);
+}
+
+ECCEhpDIRCFastPIDMap::~ECCEhpDIRCFastPIDMap()
+{
+}
+
+ECCEhpDIRCFastPIDMap::PIDCandidate_LogLikelihood_map
+ECCEhpDIRCFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta_rad) const
+{
+  assert(fTrrMap);
+
+  // preprocessing
+  double theta = theta_rad * TMath::RadToDeg();
+  truth_pid = abs(truth_pid);
+  // track_err - error assosiated with track direction [mrad]
+  double track_err = 0.326;
+  double p = momentum;
+
+  PIDCandidate_LogLikelihood_map ll_map;
+
+  // copy from DrcPidFast::
+  // pdg - Particle Data Group code of the particle
+  // mom - 3-momentum of the particle [GeV/c]
+  // track_err - error assosiated with track direction [mrad]
+  //  DrcPidInfo GetInfo(int pdg, TVector3 mom, double track_err = 0);
+
+  const int max = 5;
+  DrcPidInfo info;
+  int pid = get_pid(truth_pid);
+
+  if (pid == 0)
+  {
+    return ll_map;
+  }
+
+  // set default values
+  for (int i = 0; i < max; i++)
+  {
+    info.probability[i] = 0.25;
+    info.sigma[i] = 100;
+  }
+  info.cangle = 0;
+  info.cctr = 0;
+
+  // check range
+  //  if (theta < 19.99 || theta > 160.01){
+  //    std::cout<<"theta out of [20,160] deg range: "<<theta<<std::endl;
+  //  }
+
+  double ms_mom_err = fMs_mom->Eval(p);  // vector deviation after radiator
+
+  double alpha = (theta < 90) ? 90 - theta : theta - 90;
+  double ms_thick_frac = fMs_thickness->Eval(alpha) / fMs_thickness_max;
+
+  // 0.31 for averaging direction vector over the radiator thickness
+  double ms_err = 0.31 * ms_mom_err * ms_thick_frac;
+
+  // ctr map is for theta = [25,153] and p = [0,10] GeV/c
+  if (theta < 25) theta = 25;
+  if (theta > 153) theta = 153;
+  if (p > 10) p = 10;
+
+  int bin = fTrrMap->FindBin(theta, p);
+  double ctr = fTrrMap->GetBinContent(bin);  // Cherenkov track resolution [mrad]
+  double cctr = sqrt(ctr * ctr + track_err * track_err + ms_err * ms_err) *
+                0.001;  // combined Cherenkov track resolution[rad]
+
+  // 1.46907 - fused silica
+  double true_cangle = acos(sqrt(p * p + fMass[pid] * fMass[pid]) / p / 1.46907);
+  true_cangle += gRandom->Gaus(0, cctr);
+
+  // return default values if momentum below Cherenkov threshold (true_cangle is NaN)
+  if (isnan(true_cangle)) return ll_map;
+
+  double cangle, sum = 0, fsum = 0;
+  double delta[max] = {0};  //, probability[max] = {0};
+
+  for (int i = 0; i < max; i++)
+  {
+    cangle = acos(sqrt(p * p + fMass[i] * fMass[i]) / p / 1.46907);
+    if (isnan(cangle))
+    {
+      ll_map[get_PIDCandidate(i)] = -100;  // set non-firing particle candidate to low probability
+      continue;
+    }
+    delta[i] = fabs(cangle - true_cangle);
+    sum += delta[i];
+    info.sigma[i] = (cangle - true_cangle) / cctr;
+    if (i == pid) info.cangle = cangle;
+
+    ll_map[get_PIDCandidate(i)] = -0.5 * info.sigma[i] * info.sigma[i];
+  }
+  // normalization
+  for (int i = 0; i < max; i++)
+  {
+    if (delta[i] > 0) info.probability[i] = sum / delta[i];
+    fsum += info.probability[i];
+  }
+  for (int i = 0; i < max; i++) info.probability[i] /= fsum;
+  info.cctr = cctr;
+
+  return ll_map;
+}
+
+void ECCEhpDIRCFastPIDMap::ReadMap(const std::string &name)
+{
+  TFile *file = TFile::Open(name.c_str());
+  assert(file);
+  //  fTrrMap = new TH2F();
+  file->GetObject("htrr", fTrrMap);
+  assert(fTrrMap);
+}
+
+int ECCEhpDIRCFastPIDMap::get_pid(int pdg)
+{
+  int pid = 0;
+  if (pdg == 11) pid = 0;    // e
+  if (pdg == 13) pid = 1;    // mu
+  if (pdg == 211) pid = 2;   // pi
+  if (pdg == 321) pid = 3;   // K
+  if (pdg == 2212) pid = 4;  // p
+  return pid;
+}
+
+EICPIDDefs::PIDCandidate ECCEhpDIRCFastPIDMap::get_PIDCandidate(int pid)
+{
+  EICPIDDefs::PIDCandidate id = EICPIDDefs::InvalidCandiate;
+  if (pid == 0) id = EICPIDDefs::ElectronCandiate;  // e
+  if (pid == 1) id = EICPIDDefs::MuonCandiate;      // mu
+  if (pid == 2) id = EICPIDDefs::PionCandiate;      // pi
+  if (pid == 3) id = EICPIDDefs::KaonCandiate;      // K
+  if (pid == 4) id = EICPIDDefs::ProtonCandiate;    // p
+  assert(id != EICPIDDefs::InvalidCandiate);
+
+  return id;
+}

--- a/FastPID/ECCEhpDIRCFastPIDMap.h
+++ b/FastPID/ECCEhpDIRCFastPIDMap.h
@@ -2,7 +2,7 @@
 
 /*!
  * \file ECCEhpDIRCFastPIDMap.h
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $
@@ -22,33 +22,34 @@ class TF1;
  * \brief ECCEhpDIRCFastPIDMap
  * Import from DrcPidFast
  */
-class ECCEhpDIRCFastPIDMap : public ECCEFastPIDMap
-{
- public:
+class ECCEhpDIRCFastPIDMap : public ECCEFastPIDMap {
+public:
   ECCEhpDIRCFastPIDMap();
   virtual ~ECCEhpDIRCFastPIDMap();
 
-  PIDCandidate_LogLikelihood_map getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta) const override;
+  PIDCandidate_LogLikelihood_map
+  getFastSmearLogLikelihood(int truth_pid, const double momentum,
+                            const double theta) const override;
 
   //! read Cherenkov track resolution map from a file
   void ReadMap(const std::string &name);
 
   TH2F *GetTrrMap() { return fTrrMap; }
 
- private:
+private:
   //! probability - normalized to 1 probability for e,mu,pi,k,p
-  //! sigma - deviation of the determined Cherenkov angle from expected in terms of Cherenkov track
-  //! resolution cangle - Cherenkov angle cctr -  combined Cherenkov track resolution
-  struct DrcPidInfo
-  {
+  //! sigma - deviation of the determined Cherenkov angle from expected in terms
+  //! of Cherenkov track resolution cangle - Cherenkov angle cctr -  combined
+  //! Cherenkov track resolution
+  struct DrcPidInfo {
     double probability[5] = {0};
     double sigma[5] = {0};
     double cangle = 0;
     double cctr = 0;
   };
 
-  static int get_pid(int pdg) ;
-  static EICPIDDefs::PIDCandidate get_PIDCandidate(int id) ;
+  static int get_pid(int pdg);
+  static EICPIDDefs::PIDCandidate get_PIDCandidate(int id);
 
   TH2F *fTrrMap = nullptr;
   double fMass[5] = {0};

--- a/FastPID/ECCEhpDIRCFastPIDMap.h
+++ b/FastPID/ECCEhpDIRCFastPIDMap.h
@@ -1,0 +1,60 @@
+// $Id: $
+
+/*!
+ * \file ECCEhpDIRCFastPIDMap.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef ECCEHPDIRCFASTPIDMAP_H_
+#define ECCEHPDIRCFASTPIDMAP_H_
+
+#include "ECCEFastPIDMap.h"
+
+#include <string>
+
+class TH2F;
+class TF1;
+
+/*!
+ * \brief ECCEhpDIRCFastPIDMap
+ * Import from DrcPidFast
+ */
+class ECCEhpDIRCFastPIDMap : public ECCEFastPIDMap
+{
+ public:
+  ECCEhpDIRCFastPIDMap();
+  virtual ~ECCEhpDIRCFastPIDMap();
+
+  PIDCandidate_LogLikelihood_map getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta) const override;
+
+  //! read Cherenkov track resolution map from a file
+  void ReadMap(const std::string &name);
+
+  TH2F *GetTrrMap() { return fTrrMap; }
+
+ private:
+  //! probability - normalized to 1 probability for e,mu,pi,k,p
+  //! sigma - deviation of the determined Cherenkov angle from expected in terms of Cherenkov track
+  //! resolution cangle - Cherenkov angle cctr -  combined Cherenkov track resolution
+  struct DrcPidInfo
+  {
+    double probability[5] = {0};
+    double sigma[5] = {0};
+    double cangle = 0;
+    double cctr = 0;
+  };
+
+  static int get_pid(int pdg) ;
+  static EICPIDDefs::PIDCandidate get_PIDCandidate(int id) ;
+
+  TH2F *fTrrMap = nullptr;
+  double fMass[5] = {0};
+  TF1 *fMs_mom = nullptr;
+  TF1 *fMs_thickness = nullptr;
+  double fMs_thickness_max = (0);
+};
+
+#endif /* ECCEHPDIRCFASTPIDMAP_H_ */

--- a/FastPID/ECCEmRICHFastPIDMap.cc
+++ b/FastPID/ECCEmRICHFastPIDMap.cc
@@ -26,7 +26,7 @@ ECCEmRICHFastPIDMap::ECCEmRICHFastPIDMap(double trackResolution, double timePrec
   fTrackResolution = trackResolution;
   fTimePrecision = timePrecision;
   pLow = 3;
-  pHigh = 10.1;
+  pHigh = 20;
   c = 0.0299792458;  // cm/picosecond
   n = 1.03;          //Aerogel
   a = pixS;          // pixel size 3.0; // mm -- one side
@@ -50,7 +50,7 @@ ECCEmRICHFastPIDMap::~ECCEmRICHFastPIDMap()
 ECCEmRICHFastPIDMap::PIDCandidate_LogLikelihood_map
 ECCEmRICHFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta_rad) const
 {
-  int abs_truth_pid = abs(truth_pid);
+  const int abs_truth_pid = abs(truth_pid);
 
   PIDCandidate_LogLikelihood_map ll_map;
 

--- a/FastPID/ECCEmRICHFastPIDMap.cc
+++ b/FastPID/ECCEmRICHFastPIDMap.cc
@@ -1,0 +1,208 @@
+// $Id: $
+
+/*!
+ * \file ECCEmRICHFastPIDMap.cc
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include "ECCEmRICHFastPIDMap.h"
+
+#include <TF1.h>
+#include <TFile.h>
+#include <TH2F.h>
+#include <TMath.h>
+#include <TRandom.h>
+#include <TVector3.h>
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+
+ECCEmRICHFastPIDMap::ECCEmRICHFastPIDMap(double trackResolution, double timePrecision, double pixS)
+{
+  fTrackResolution = trackResolution;
+  fTimePrecision = timePrecision;
+  pLow = 3;
+  pHigh = 10.1;
+  c = 0.0299792458;  // cm/picosecond
+  n = 1.03;          //Aerogel
+  a = pixS;          // pixel size 3.0; // mm -- one side
+  f = 152.4;         //focal length mm =  6"
+  N_gam = 10;
+  mPion = 0.13957018;       //GeV/c^2
+  mKaon = 0.493677;         //GeV/c^2
+  mProton = 0.93827208816;  //GeV/c^2
+  pi = 3.14159;
+  alpha = 0.0072973525693;  // hyperfine const
+  L = 3.0;                  //Aerogel block thickness in cm
+
+  //===============
+  th0 = 0.;  //incidence angle in radians
+}
+
+ECCEmRICHFastPIDMap::~ECCEmRICHFastPIDMap()
+{
+}
+
+ECCEmRICHFastPIDMap::PIDCandidate_LogLikelihood_map
+ECCEmRICHFastPIDMap::getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta_rad) const
+{
+  int abs_truth_pid = abs(truth_pid);
+
+  PIDCandidate_LogLikelihood_map ll_map;
+
+  if (abs_truth_pid != EICPIDDefs::PionCandiate and abs_truth_pid != EICPIDDefs::KaonCandiate and abs_truth_pid != EICPIDDefs::ProtonCandiate)
+  {
+    // not processing non-hadronic tracks
+    if (Verbosity())
+      std::cout << __PRETTY_FUNCTION__ << ":  not processing non-hadronic tracks " << truth_pid << std::endl;
+
+    return ll_map;
+  }
+  if (theta_rad < m_acceptanceThetaMin or theta_rad > m_acceptanceThetaMax)
+  {
+    // not processing out of acceptance tracks
+    if (Verbosity())
+      std::cout << __PRETTY_FUNCTION__ << ": not processing out of acceptance tracks theta_rad = " << theta_rad << std::endl;
+
+    return ll_map;
+  }
+  if (momentum < pLow or momentum > pHigh)
+  {
+    // not processing out of acceptance tracks
+    if (Verbosity())
+      std::cout << __PRETTY_FUNCTION__ << ": not processing out of acceptance tracks momentum = " << momentum << std::endl;
+
+    return ll_map;
+  }
+
+  double Nsigma_piK = 0;
+  double Nsigma_Kp = 0;
+
+  {
+    //Angle difference
+    double dth = getAng(mPion, momentum) - getAng(mKaon, momentum);
+    //Detector uncertainty
+    double sigTh = sqrt(pow(getdAng(mPion, momentum), 2) + pow(getdAng(mKaon, momentum), 2));
+    //Global uncertainty
+    double sigThTrk = sqrt(pow(getdAngTrk(mPion, momentum), 2) + pow(getdAngTrk(mKaon, momentum), 2));
+    double sigThc = sqrt(pow(sigTh / sqrt(getNgamma(L, mKaon, momentum)), 2) + pow(sigThTrk, 2));
+    Nsigma_piK = dth / sigThc;
+    if (isnan(Nsigma_piK)) Nsigma_piK = 0;
+  }
+  {
+    //Angle difference
+    double dth = getAng(mKaon, momentum) - getAng(mProton, momentum);
+    //Detector uncertainty
+    double sigTh = sqrt(pow(getdAng(mKaon, momentum), 2) + pow(getdAng(mProton, momentum), 2));
+    //Global uncertainty
+    double sigThTrk = sqrt(pow(getdAngTrk(mKaon, momentum), 2) + pow(getdAngTrk(mProton, momentum), 2));
+    double sigThc = sqrt(pow(sigTh / sqrt(getNgamma(L, mProton, momentum)), 2) + pow(sigThTrk, 2));
+    Nsigma_Kp = dth / sigThc;
+
+    if (isnan(Nsigma_Kp)) Nsigma_Kp = 0;
+  }
+
+  if (Verbosity())
+    std::cout << __PRETTY_FUNCTION__ << ": processing tracks momentum = " << momentum
+              << " Nsigma_piK = " << Nsigma_piK << " Nsigma_Kp = " << Nsigma_Kp
+              << std::endl;
+
+  const double pion_sigma_space_ring_radius = +Nsigma_piK;
+  const double kaon_sigma_space_ring_radius = 0;
+  const double proton_sigma_space_ring_radius = -Nsigma_Kp;
+
+  double sigma_space_ring_radius = gRandom->Gaus(0, 1);
+  if (abs_truth_pid == EICPIDDefs::PionCandiate)
+    sigma_space_ring_radius += pion_sigma_space_ring_radius;
+  else if (abs_truth_pid == EICPIDDefs::KaonCandiate)
+    sigma_space_ring_radius += kaon_sigma_space_ring_radius;
+  else if (abs_truth_pid == EICPIDDefs::ProtonCandiate)
+    sigma_space_ring_radius += proton_sigma_space_ring_radius;
+
+  ll_map[EICPIDDefs::PionCandiate] = -0.5 * pow(sigma_space_ring_radius - pion_sigma_space_ring_radius, 2);
+  ll_map[EICPIDDefs::KaonCandiate] = -0.5 * pow(sigma_space_ring_radius - kaon_sigma_space_ring_radius, 2);
+  ll_map[EICPIDDefs::ProtonCandiate] = -0.5 * pow(sigma_space_ring_radius - proton_sigma_space_ring_radius, 2);
+
+  return ll_map;
+}
+
+//Angle exiting the Aerogel
+double ECCEmRICHFastPIDMap::getAng(double mass, double mom) const
+{
+  double beta = mom / sqrt(pow(mom, 2) + pow(mass, 2));
+  double thc = acos(1. / n / beta);
+  double th0p = asin(sin(th0) / n);
+  double dthc = thc - th0p;
+  double theta = asin(n * sin(dthc));
+
+  return theta;
+}
+
+//Uncertainty due to detector effects
+double ECCEmRICHFastPIDMap::getdAng(double mass, double mom) const
+{
+  double beta = mom / sqrt(pow(mom, 2) + pow(mass, 2));
+  double thc = acos(1. / n / beta);
+  double th0p = asin(sin(th0) / n);
+  double dthc = thc - th0p;
+  double theta = asin(n * sin(dthc));
+
+  double sig_ep = 0;    //Emission point error
+  double sig_chro = 0;  //Chromatic dispersion error
+  double sig_pix = a * pow(cos(theta), 2) / f / sqrt(12.);
+  ;
+
+  double sigTh = sqrt(pow(sig_ep, 2) + pow(sig_chro, 2) + pow(sig_pix, 2));
+
+  return sigTh;
+}
+
+//Uncertainty due to tracking resolution
+double ECCEmRICHFastPIDMap::getdAngTrk(double mass, double mom) const
+{
+  double beta = mom / sqrt(pow(mom, 2) + pow(mass, 2));
+  double thc = acos(1. / n / beta);
+  double th0p = asin(sin(th0) / n);
+  double dthc = thc - th0p;
+  double theta = asin(n * sin(dthc));
+
+  double sig_trk = (cos(dthc) / cos(theta)) * (cos(th0) / cos(th0p)) * fTrackResolution;
+  ;
+
+  return sig_trk;
+}
+
+//no. of gamms
+double ECCEmRICHFastPIDMap::getNgamma(double t, double mass, double mom) const
+{
+  int tot = 10000;
+  double beta = mom / sqrt(pow(mom, 2) + pow(mass, 2));
+  double fact = 2. * pi * alpha * t * (1. - 1. / pow(n * beta, 2));
+  double T_lensWin = 0.92 * 0.92;
+  double xmin = 300.e-7;
+  double xmax = 650.e-7;
+  double dx = (xmax - xmin) / tot;
+  double sum = 0;
+  for (int j = 0; j < tot; j++)
+  {
+    double x = xmin + j * dx + dx / 2.;
+    sum += T_QE(x) * T_Aer(t, x) / pow(x, 2);
+  }
+  return fact * T_lensWin * sum * dx;
+}
+
+//Quantum efficiency
+double ECCEmRICHFastPIDMap::T_QE(double lam) const
+{
+  return 0.34 * exp(-1. * pow(lam - 345.e-7, 2) / (2. * pow(119.e-7, 2)));
+}
+
+//Transmissions of the radiator block
+double ECCEmRICHFastPIDMap::T_Aer(double t, double lam) const
+{
+  return 0.83 * exp(-1. * t * 56.29e-20 / pow(lam, 4));
+}

--- a/FastPID/ECCEmRICHFastPIDMap.cc
+++ b/FastPID/ECCEmRICHFastPIDMap.cc
@@ -154,7 +154,6 @@ double ECCEmRICHFastPIDMap::getdAng(double mass, double mom) const
   double sig_ep = 0;    //Emission point error
   double sig_chro = 0;  //Chromatic dispersion error
   double sig_pix = a * pow(cos(theta), 2) / f / sqrt(12.);
-  ;
 
   double sigTh = sqrt(pow(sig_ep, 2) + pow(sig_chro, 2) + pow(sig_pix, 2));
 
@@ -171,7 +170,6 @@ double ECCEmRICHFastPIDMap::getdAngTrk(double mass, double mom) const
   double theta = asin(n * sin(dthc));
 
   double sig_trk = (cos(dthc) / cos(theta)) * (cos(th0) / cos(th0p)) * fTrackResolution;
-  ;
 
   return sig_trk;
 }

--- a/FastPID/ECCEmRICHFastPIDMap.h
+++ b/FastPID/ECCEmRICHFastPIDMap.h
@@ -2,7 +2,7 @@
 
 /*!
  * \file ECCEmRICHFastPIDMap.h
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $
@@ -22,26 +22,25 @@ class TF1;
  * \brief ECCEmRICHFastPIDMap
  * Import from ./mRICH/mRICH
  */
-class ECCEmRICHFastPIDMap : public ECCEFastPIDMap
-{
- public:
-
+class ECCEmRICHFastPIDMap : public ECCEFastPIDMap {
+public:
   //   Detectors.push_back( new mRICH(0.00175, 1, 3, mom) ); // 20 psec @ 100 cm
-  ECCEmRICHFastPIDMap(double trackResolution = 0.00175, double timePrecision = 1.0, double pixS = 3);
+  ECCEmRICHFastPIDMap(double trackResolution = 0.00175,
+                      double timePrecision = 1.0, double pixS = 3);
   virtual ~ECCEmRICHFastPIDMap();
 
-  PIDCandidate_LogLikelihood_map getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta) const override;
+  PIDCandidate_LogLikelihood_map
+  getFastSmearLogLikelihood(int truth_pid, const double momentum,
+                            const double theta) const override;
 
-  void setThetaAcceptanceMinMax(double min, double max)
-  {
+  void setThetaAcceptanceMinMax(double min, double max) {
     m_acceptanceThetaMin = min;
     m_acceptanceThetaMax = max;
   }
 
-
- private:
-  double m_acceptanceThetaMin = 2.658;  // eta = -1.4;
-  double m_acceptanceThetaMax = 3.04;   // eta = -3
+private:
+  double m_acceptanceThetaMin = 2.658; // eta = -1.4;
+  double m_acceptanceThetaMax = 3.04;  // eta = -3
 
   double getAng(double mass, double mom) const;
   double getdAng(double mass, double mom) const;
@@ -51,13 +50,13 @@ class ECCEmRICHFastPIDMap : public ECCEFastPIDMap
   double T_QE(double lam) const;
 
   // Physical constants (should come from elsewhere!)
-  double mPion;    // GeV/c^2
-  double mKaon;    // GeV/c^2
-  double mProton;  // GeV/c^2
-  double c;        // cm/picosecond;
+  double mPion;   // GeV/c^2
+  double mKaon;   // GeV/c^2
+  double mProton; // GeV/c^2
+  double c;       // cm/picosecond;
   double n;
-  double f;  //mm
-  double a;  //mm
+  double f; // mm
+  double a; // mm
   double N_gam;
   double pi;
   double alpha;

--- a/FastPID/ECCEmRICHFastPIDMap.h
+++ b/FastPID/ECCEmRICHFastPIDMap.h
@@ -25,7 +25,9 @@ class TF1;
 class ECCEmRICHFastPIDMap : public ECCEFastPIDMap
 {
  public:
-  ECCEmRICHFastPIDMap(double trackResolution = 0.5, double timePrecision = 1.0, double pixS = 0.5);
+
+  //   Detectors.push_back( new mRICH(0.00175, 1, 3, mom) ); // 20 psec @ 100 cm
+  ECCEmRICHFastPIDMap(double trackResolution = 0.00175, double timePrecision = 1.0, double pixS = 3);
   virtual ~ECCEmRICHFastPIDMap();
 
   PIDCandidate_LogLikelihood_map getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta) const override;

--- a/FastPID/ECCEmRICHFastPIDMap.h
+++ b/FastPID/ECCEmRICHFastPIDMap.h
@@ -1,0 +1,80 @@
+// $Id: $
+
+/*!
+ * \file ECCEmRICHFastPIDMap.h
+ * \brief 
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#ifndef ECCEmRICHFastPIDMap_H_
+#define ECCEmRICHFastPIDMap_H_
+
+#include "ECCEFastPIDMap.h"
+
+#include <string>
+
+class TH2F;
+class TF1;
+
+/*!
+ * \brief ECCEmRICHFastPIDMap
+ * Import from ./mRICH/mRICH
+ */
+class ECCEmRICHFastPIDMap : public ECCEFastPIDMap
+{
+ public:
+  ECCEmRICHFastPIDMap(double trackResolution = 0.5, double timePrecision = 1.0, double pixS = 0.5);
+  virtual ~ECCEmRICHFastPIDMap();
+
+  PIDCandidate_LogLikelihood_map getFastSmearLogLikelihood(int truth_pid, const double momentum, const double theta) const override;
+
+  void setThetaAcceptanceMinMax(double min, double max)
+  {
+    m_acceptanceThetaMin = min;
+    m_acceptanceThetaMax = max;
+  }
+
+  /// Sets the verbosity of this module (0 by default=quiet).
+  virtual void Verbosity(const int ival) { m_Verbosity = ival; }
+
+  /// Gets the verbosity of this module.
+  virtual int Verbosity() const { return m_Verbosity; }
+
+ private:
+  double m_acceptanceThetaMin = 2.658;  // eta = -1.4;
+  double m_acceptanceThetaMax = 3.04;   // eta = -3
+
+  double getAng(double mass, double mom) const;
+  double getdAng(double mass, double mom) const;
+  double getdAngTrk(double mass, double mom) const;
+  double getNgamma(double t, double mass, double mom) const;
+  double T_Aer(double t, double lam) const;
+  double T_QE(double lam) const;
+
+  // Physical constants (should come from elsewhere!)
+  double mPion;    // GeV/c^2
+  double mKaon;    // GeV/c^2
+  double mProton;  // GeV/c^2
+  double c;        // cm/picosecond;
+  double n;
+  double f;  //mm
+  double a;  //mm
+  double N_gam;
+  double pi;
+  double alpha;
+  double L;
+  double th0;
+
+  double fTrackResolution;
+  double fTimePrecision;
+
+  double pLow;
+  double pHigh;
+
+  /// The verbosity level. 0 means not verbose at all.
+  int m_Verbosity = 0;
+};
+
+#endif /* ECCEmRICHFastPIDMap_H_ */

--- a/FastPID/ECCEmRICHFastPIDMap.h
+++ b/FastPID/ECCEmRICHFastPIDMap.h
@@ -38,11 +38,6 @@ class ECCEmRICHFastPIDMap : public ECCEFastPIDMap
     m_acceptanceThetaMax = max;
   }
 
-  /// Sets the verbosity of this module (0 by default=quiet).
-  virtual void Verbosity(const int ival) { m_Verbosity = ival; }
-
-  /// Gets the verbosity of this module.
-  virtual int Verbosity() const { return m_Verbosity; }
 
  private:
   double m_acceptanceThetaMin = 2.658;  // eta = -1.4;
@@ -74,9 +69,6 @@ class ECCEmRICHFastPIDMap : public ECCEFastPIDMap
 
   double pLow;
   double pHigh;
-
-  /// The verbosity level. 0 means not verbose at all.
-  int m_Verbosity = 0;
 };
 
 #endif /* ECCEmRICHFastPIDMap_H_ */

--- a/FastPID/Makefile.am
+++ b/FastPID/Makefile.am
@@ -1,0 +1,49 @@
+AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -I$(ROOTSYS)/include
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(OFFLINE_MAIN)/lib64
+
+pkginclude_HEADERS = \
+  ECCEFastPIDReco.h \
+  ECCEFastPIDMap.h
+
+lib_LTLIBRARIES = \
+  libECCEFastPIDReco.la
+
+libECCEFastPIDReco_la_SOURCES = \
+  ECCEFastPIDReco.cc \
+  ECCEFastPIDMap.cc
+
+libECCEFastPIDReco_la_LIBADD = \
+  -lphool \
+  -leicpidbase \
+  -lg4detectors_io \
+  -lphg4hit \
+  -lSubsysReco\
+  -ltrack_reco_io \
+  -ltrackbase_historic_io
+
+BUILT_SOURCES = testexternals.cc
+
+noinst_PROGRAMS = \
+  testexternals
+
+testexternals_SOURCES = testexternals.cc
+testexternals_LDADD   = libECCEFastPIDReco.la
+
+testexternals.cc:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f $(BUILT_SOURCES)

--- a/FastPID/Makefile.am
+++ b/FastPID/Makefile.am
@@ -13,7 +13,9 @@ AM_LDFLAGS = \
 pkginclude_HEADERS = \
   ECCEFastPIDReco.h \
   ECCEFastPIDMap.h \
-  ECCEhpDIRCFastPIDMap.h
+  ECCEhpDIRCFastPIDMap.h \
+  ECCEmRICHFastPIDMap.h \
+  ECCEdRICHFastPIDMap.h
 
 lib_LTLIBRARIES = \
   libECCEFastPIDReco.la
@@ -21,7 +23,9 @@ lib_LTLIBRARIES = \
 libECCEFastPIDReco_la_SOURCES = \
   ECCEFastPIDReco.cc \
   ECCEFastPIDMap.cc \
-  ECCEhpDIRCFastPIDMap.cc
+  ECCEhpDIRCFastPIDMap.cc \
+  ECCEdRICHFastPIDMap.cc \
+  ECCEmRICHFastPIDMap.cc
 
 libECCEFastPIDReco_la_LIBADD = \
   -lphool \

--- a/FastPID/Makefile.am
+++ b/FastPID/Makefile.am
@@ -12,14 +12,16 @@ AM_LDFLAGS = \
 
 pkginclude_HEADERS = \
   ECCEFastPIDReco.h \
-  ECCEFastPIDMap.h
+  ECCEFastPIDMap.h \
+  ECCEhpDIRCFastPIDMap.h
 
 lib_LTLIBRARIES = \
   libECCEFastPIDReco.la
 
 libECCEFastPIDReco_la_SOURCES = \
   ECCEFastPIDReco.cc \
-  ECCEFastPIDMap.cc
+  ECCEFastPIDMap.cc \
+  ECCEhpDIRCFastPIDMap.cc
 
 libECCEFastPIDReco_la_LIBADD = \
   -lphool \
@@ -28,7 +30,8 @@ libECCEFastPIDReco_la_LIBADD = \
   -lphg4hit \
   -lSubsysReco\
   -ltrack_reco_io \
-  -ltrackbase_historic_io
+  -ltrackbase_historic_io \
+  -lCLHEP
 
 BUILT_SOURCES = testexternals.cc
 

--- a/FastPID/autogen.sh
+++ b/FastPID/autogen.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"

--- a/FastPID/configure.ac
+++ b/FastPID/configure.ac
@@ -1,0 +1,16 @@
+AC_INIT(eccefastpidreco,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+
+AM_INIT_AUTOMAKE
+AC_PROG_CXX(CC g++)
+
+LT_INIT([disable-static])
+
+dnl   no point in suppressing warnings people should 
+dnl   at least see them, so here we go for g++: -Wall
+if test $ac_cv_prog_gxx = yes; then
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+fi
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
Import standalone fast PID code into reco module, utilizes PID infrastructure at https://github.com/eic/fun4all_eicdetectors/pull/61

Example output, 14 GeV pion with a marginal differential power from DIRC with `m_tr_pion_loglikelihood` not far from `m_tr_kaon_loglikelihood ` , and it is still well separated from proton hyposis: 
```
root [4] tracktree->Show(10)
======> EVENT:10
 m_tr_px         = 7.71799
 m_tr_py         = -9.48757
 m_tr_pz         = -7.2438
 m_tr_p          = 14.2146
 m_tr_pt         = 12.2303
 m_tr_phi        = -0.887887
 m_tr_eta        = -0.562195
 m_charge        = -1
 m_chisq         = 15.1772
 m_ndf           = 13
 m_dca           = 0.000290063
 m_tr_x          = -3.62858e-05
 m_tr_y          = -2.95819e-05
 m_tr_z          = 4.0154
 m_tr_pion_loglikelihood = -0.232099
 m_tr_kaon_loglikelihood = -1.79295
 m_tr_proton_loglikelihood = -14.2288
 m_truth_is_primary = 1
 m_truthtrackpx  = 7.72646
 m_truthtrackpy  = -9.49924
 m_truthtrackpz  = -7.25277
 m_truthtrackp   = 14.2315
 m_truthtracke   = 14.2322
 m_truthtrackpt  = 12.2447
 m_truthtrackphi = -0.887952
 m_truthtracketa = -0.562226
 m_truthtrackpid = -211
```